### PR TITLE
errutil.NewErrorSlice is now errutil.NewErrors

### DIFF
--- a/config/input.go
+++ b/config/input.go
@@ -58,7 +58,7 @@ func (t *Config) getInputs(evchan chan logevent.LogEvent) (inputs []TypeInputCon
 		inj.Map(evchan)
 		refvs, err := injectutil.Invoke(inj, handler)
 		if err != nil {
-			err = errutil.NewErrorSlice(fmt.Errorf("handle input config failed: %q", confraw), err)
+			err = errutil.NewErrors(fmt.Errorf("handle input config failed: %q", confraw), err)
 			return []TypeInputConfig{}, err
 		}
 

--- a/config/output.go
+++ b/config/output.go
@@ -67,7 +67,7 @@ func (t *Config) getOutputs() (outputs []TypeOutputConfig, err error) {
 		inj.Map(&confraw)
 		refvs, err := injectutil.Invoke(inj, handler)
 		if err != nil {
-			err = errutil.NewErrorSlice(fmt.Errorf("handle output config failed: %q", confraw), err)
+			err = errutil.NewErrors(fmt.Errorf("handle output config failed: %q", confraw), err)
 			return []TypeOutputConfig{}, err
 		}
 

--- a/input/exec/inputexec.go
+++ b/input/exec/inputexec.go
@@ -110,7 +110,7 @@ func (self *InputConfig) Exec(evchan chan logevent.LogEvent, logger *logrus.Logg
 
 	if len(errs) > 0 {
 		event.AddTag("inputexec_failed")
-		event.Extra["error"] = errutil.NewErrorSlice(errs...).Error()
+		event.Extra["error"] = errutil.NewErrors(errs...).Error()
 	}
 
 	logger.Debugf("%+v", event)

--- a/input/file/inputfile.go
+++ b/input/file/inputfile.go
@@ -85,7 +85,7 @@ func (t *InputConfig) start(logger *logrus.Logger, evchan chan logevent.LogEvent
 	}
 
 	if matches, err = filepath.Glob(t.Path); err != nil {
-		return errutil.NewErrorSlice(fmt.Errorf("glob(%q) failed", t.Path), err)
+		return errutil.NewErrors(fmt.Errorf("glob(%q) failed", t.Path), err)
 	}
 
 	go t.CheckSaveSinceDBInfosLoop()


### PR DESCRIPTION
`github.com/tsaikd/KDGoLib/erruti`l apparently changed its API for errutil: `errutil.NewErrorSlice` is now `errutil.NewErrors`

