### PR TITLE
Filter: parse log message containing JSON string

### DIFF
--- a/filter/json/filterjson.go
+++ b/filter/json/filterjson.go
@@ -1,10 +1,11 @@
 package filterjson
 
 import (
-	"github.com/tsaikd/gogstash/config"
-	"github.com/tsaikd/gogstash/config/logevent"
 	"encoding/json"
 	"time"
+
+	"github.com/tsaikd/gogstash/config"
+	"github.com/tsaikd/gogstash/config/logevent"
 )
 
 const (
@@ -13,8 +14,8 @@ const (
 
 type FilterConfig struct {
 	config.FilterConfig
-	Msgfield   string `json:"message"`
-	Tsfield string `json:"timestamp"`
+	Msgfield string `json:"message"`
+	Tsfield  string `json:"timestamp"`
 	Tsformat string `json:"timeformat"`
 }
 
@@ -64,4 +65,3 @@ func (f *FilterConfig) Event(event logevent.LogEvent) logevent.LogEvent {
 
 	return event
 }
-

--- a/filter/json/filterjson.go
+++ b/filter/json/filterjson.go
@@ -1,0 +1,67 @@
+package filterjson
+
+import (
+	"github.com/tsaikd/gogstash/config"
+	"github.com/tsaikd/gogstash/config/logevent"
+	"encoding/json"
+	"time"
+)
+
+const (
+	ModuleName = "json"
+)
+
+type FilterConfig struct {
+	config.FilterConfig
+	Msgfield   string `json:"message"`
+	Tsfield string `json:"timestamp"`
+	Tsformat string `json:"timeformat"`
+}
+
+func DefaultFilterConfig() FilterConfig {
+	return FilterConfig{
+		FilterConfig: config.FilterConfig{
+			CommonConfig: config.CommonConfig{
+				Type: ModuleName,
+			},
+		},
+	}
+}
+
+func InitHandler(confraw *config.ConfigRaw) (retconf config.TypeFilterConfig, err error) {
+	conf := DefaultFilterConfig()
+	if err = config.ReflectConfig(confraw, &conf); err != nil {
+		return
+	}
+
+	retconf = &conf
+	return
+}
+
+func (f *FilterConfig) Event(event logevent.LogEvent) logevent.LogEvent {
+
+	var parsedMessage map[string]interface{}
+	if err := json.Unmarshal([]byte(event.Message), &parsedMessage); err != nil {
+		return event
+	}
+
+	if event.Extra == nil {
+		event.Extra = make(map[string]interface{})
+	}
+
+	for key, value := range parsedMessage {
+		switch key {
+		case f.Msgfield:
+			event.Message = value.(string)
+		case f.Tsfield:
+			if ts, err := time.Parse(f.Tsformat, value.(string)); err == nil {
+				event.Timestamp = ts
+			}
+		default:
+			event.Extra[key] = value
+		}
+	}
+
+	return event
+}
+

--- a/filter/json/filterjson_test.go
+++ b/filter/json/filterjson_test.go
@@ -1,0 +1,64 @@
+package filterjson
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/tsaikd/gogstash/config"
+	"github.com/tsaikd/gogstash/config/logevent"
+)
+
+var (
+	logger = config.Logger
+)
+
+func init() {
+	logger.Level = logrus.DebugLevel
+	config.RegistFilterHandler(ModuleName, InitHandler)
+}
+
+func Test_main(t *testing.T) {
+	require := require.New(t)
+	require.NotNil(require)
+
+	conf, err := config.LoadFromString(`{
+		"filter": [{
+			"type": "json",
+            "message": "message",
+            "timestamp": "time",
+            "timeformat": "2006-01-02T15:04:05Z"
+		}]
+	}`)
+	require.NoError(err)
+
+	timestamp, _ := time.Parse("2006-01-02T15:04:05Z", "2016-12-04T09:09:41.193Z")
+
+	expectedEvent := logevent.LogEvent{
+		Timestamp: timestamp,
+		Message:   "Test",
+		Extra: map[string]interface{}{
+			"host": "Hostname",
+		},
+	}
+
+	inchan := conf.Get(reflect.TypeOf(make(config.InChan))).
+		Interface().(config.InChan)
+
+	outchan := conf.Get(reflect.TypeOf(make(config.OutChan))).
+		Interface().(config.OutChan)
+
+	err = conf.RunFilters()
+
+	inchan <- logevent.LogEvent{
+		Timestamp: time.Now(),
+		Message:   "{ \"message\": \"Test\", \"host\": \"Hostname\", \"time\":\"2016-12-04T09:09:41.193Z\" }",
+	}
+
+	event := <-outchan
+
+	require.Equal(expectedEvent, event)
+	require.NoError(err)
+}

--- a/modloader/modloader.go
+++ b/modloader/modloader.go
@@ -3,6 +3,7 @@ package modloader
 import (
 	"github.com/tsaikd/gogstash/config"
 	"github.com/tsaikd/gogstash/filter/addfield"
+	"github.com/tsaikd/gogstash/filter/json"
 	"github.com/tsaikd/gogstash/input/dockerlog"
 	"github.com/tsaikd/gogstash/input/dockerstats"
 	"github.com/tsaikd/gogstash/input/exec"
@@ -27,6 +28,7 @@ func init() {
 	config.RegistInputHandler(inputsocket.ModuleName, inputsocket.InitHandler)
 
 	config.RegistFilterHandler(filteraddfield.ModuleName, filteraddfield.InitHandler)
+	config.RegistFilterHandler(filterjson.ModuleName, filterjson.InitHandler)
 
 	config.RegistOutputHandler(outputstdout.ModuleName, outputstdout.InitHandler)
 	config.RegistOutputHandler(outputelastic.ModuleName, outputelastic.InitHandler)


### PR DESCRIPTION
I've created a `filter` that parses a log string containing JSON data into a new `message` and extra fields.

Example config:
```json
"filter": [
        {
	    "type": "json",
            "message": "msg",
            "timestamp": "time",
            "timeformat": "2006-01-02T15:04:05Z"
        }
 ]
```

- `message` defines the JSON field that contains the original message string (optional),all other fields are set as extra fields
- `timestamp` defines the JSON field that contains the timestamp of the log event (optional)
- `timeformat` defines the time format of the timestamp 

Some of my services log JSON. Right now Gogstash logs this JSON as a single message. But (e.g. in ElasticSearch) I want access to every JSON field.

So given this log string:
```
{"name":"Streamproxy","hostname":"hostname","pid":29,"level":30,"module":"Mymodule","mount":"/mymount","ip":"1.1.1.1","msg":"Connection Start","time":"2016-12-04T09:09:41.193Z"}
```

My filter creates this log output:
```
{
        "@timestamp": "2016-12-04T09:09:41.193Z",
        "hostname": "hostname",
        "ip": "1.1.1.1",
        "level": 30,
        "message": "Connection start",
        "module": "MyModule",
        "mount": "/mymount",
        "offset": 0,
        "pid": 29
}
```