### PR TITLE
Add redis input, http listen input, ES5.0 output support

### DIFF
--- a/cmd/gogstash.go
+++ b/cmd/gogstash.go
@@ -7,8 +7,8 @@ import (
 	"github.com/tsaikd/gogstash/config"
 
 	// module loader
-	_ "github.com/tsaikd/gogstash/modloader"
 	"github.com/Sirupsen/logrus"
+	_ "github.com/tsaikd/gogstash/modloader"
 )
 
 func gogstash(confpath string, debug bool) (err error) {

--- a/cmd/gogstash.go
+++ b/cmd/gogstash.go
@@ -8,10 +8,15 @@ import (
 
 	// module loader
 	_ "github.com/tsaikd/gogstash/modloader"
+	"github.com/Sirupsen/logrus"
 )
 
-func gogstash(confpath string) (err error) {
+func gogstash(confpath string, debug bool) (err error) {
 	logger := config.Logger
+
+	if debug {
+		logger.Level = logrus.DebugLevel
+	}
 
 	if runtime.GOMAXPROCS(0) == 1 && runtime.NumCPU() > 1 {
 		logger.Warnf("set GOMAXPROCS = %d to get better performance", runtime.NumCPU())
@@ -33,6 +38,8 @@ func gogstash(confpath string) (err error) {
 	if err = conf.RunOutputs(); err != nil {
 		return
 	}
+
+	logger.Info("gogstash started...")
 
 	for {
 		// all event run in routine, go into infinite sleep

--- a/cmd/module.go
+++ b/cmd/module.go
@@ -13,6 +13,12 @@ var (
 		Usage:   "Path to configuration file",
 		EnvVar:  "CONFIG",
 	}
+	flagDebug = &cobrather.BoolFlag{
+		Name: 	"debug",
+		Default: false,
+		Usage:	"Enable debug logging",
+		EnvVar:	"DEBUG",
+	}
 )
 
 // Module info
@@ -24,8 +30,9 @@ var Module = &cobrather.Module{
 	},
 	Flags: []cobrather.Flag{
 		flagConfig,
+		flagDebug,
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return gogstash(flagConfig.String())
+		return gogstash(flagConfig.String(), flagDebug.Bool())
 	},
 }

--- a/cmd/module.go
+++ b/cmd/module.go
@@ -14,10 +14,10 @@ var (
 		EnvVar:  "CONFIG",
 	}
 	flagDebug = &cobrather.BoolFlag{
-		Name: 	"debug",
+		Name:    "debug",
 		Default: false,
-		Usage:	"Enable debug logging",
-		EnvVar:	"DEBUG",
+		Usage:   "Enable debug logging",
+		EnvVar:  "DEBUG",
 	}
 )
 

--- a/input/httplisten/httplisten.go
+++ b/input/httplisten/httplisten.go
@@ -2,11 +2,11 @@ package httplisten
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/Sirupsen/logrus"
 	"github.com/tsaikd/gogstash/config"
 	"github.com/tsaikd/gogstash/config/logevent"
 	"net/http"
-	"fmt"
 )
 
 // ModuleName is the name used in config file
@@ -19,9 +19,9 @@ const invalidAccessToken = "Invalid access token. Access denied."
 // InputConfig holds the output configuration json fields
 type InputConfig struct {
 	config.InputConfig
-	Address string `json:"address"`	// host:port to listen on
-	Path	string `json:"path"` 	// The path to accept json HTTP POST requests on
-	RequireHeader	[]string `json:"require_header"` // Require this header to be present to accept the POST ("X-Access-Token: Potato")
+	Address       string   `json:"address"`        // host:port to listen on
+	Path          string   `json:"path"`           // The path to accept json HTTP POST requests on
+	RequireHeader []string `json:"require_header"` // Require this header to be present to accept the POST ("X-Access-Token: Potato")
 }
 
 // DefaultInputConfig returns an InputConfig struct with default values
@@ -32,8 +32,8 @@ func DefaultInputConfig() InputConfig {
 				Type: ModuleName,
 			},
 		},
-		Address: "0.0.0.0:8080",
-		Path: "/",
+		Address:       "0.0.0.0:8080",
+		Path:          "/",
 		RequireHeader: []string{},
 	}
 }
@@ -52,10 +52,9 @@ func (i *InputConfig) Start() {
 	i.Invoke(i.start)
 }
 
-
 // Start the HTTP listener and send all requests matching config to it
 func (i *InputConfig) start(logger *logrus.Logger, inchan config.InChan) {
-	http.HandleFunc(i.Path, func(rw http.ResponseWriter, req *http.Request){
+	http.HandleFunc(i.Path, func(rw http.ResponseWriter, req *http.Request) {
 		// Only allow POST requests (for now).
 		if req.Method != http.MethodPost {
 			logger.Warnf(invalidMethodError, req.Method)

--- a/input/httplisten/httplisten.go
+++ b/input/httplisten/httplisten.go
@@ -1,0 +1,89 @@
+package httplisten
+
+import (
+	"encoding/json"
+	"github.com/Sirupsen/logrus"
+	"github.com/tsaikd/gogstash/config"
+	"github.com/tsaikd/gogstash/config/logevent"
+	"net/http"
+	"fmt"
+)
+
+// ModuleName is the name used in config file
+const ModuleName = "httplisten"
+
+const invalidMethodError = "Method not allowed: '%v'"
+const invalidJsonError = "Invalid JSON received on HTTP listener. Decoder error: %+v"
+
+// InputConfig holds the output configuration json fields
+type InputConfig struct {
+	config.InputConfig
+	Address string `json:"address"`	// host:port to listen on
+	Path	string `json:"path"` 	// The path to accept json HTTP POST requests on
+	RequireHeader	string `json:"require_header"` // Require this header to be present to accept the POST
+}
+
+// DefaultInputConfig returns an InputConfig struct with default values
+func DefaultInputConfig() InputConfig {
+	return InputConfig{
+		InputConfig: config.InputConfig{
+			CommonConfig: config.CommonConfig{
+				Type: ModuleName,
+			},
+		},
+		Address: "0.0.0.0:8080",
+		Path: "/",
+		RequireHeader: "",
+	}
+}
+
+// InitHandler initialize the input plugin
+func InitHandler(confraw *config.ConfigRaw) (config.TypeInputConfig, error) {
+	conf := DefaultInputConfig()
+	if err := config.ReflectConfig(confraw, &conf); err != nil {
+		return nil, err
+	}
+	return &conf, nil
+}
+
+// Start wraps the actual function starting the plugin
+func (i *InputConfig) Start() {
+	i.Invoke(i.start)
+}
+
+
+// Start the HTTP listener and send all requests matching config to it
+func (i *InputConfig) start(logger *logrus.Logger, inchan config.InChan) {
+	http.HandleFunc(i.Path, func(rw http.ResponseWriter, req *http.Request){
+		// Only allow POST requests (for now).
+		if req.Method != http.MethodPost {
+			logger.Warnf(invalidMethodError, req.Method)
+			rw.WriteHeader(http.StatusMethodNotAllowed)
+			rw.Write([]byte(fmt.Sprintf(invalidMethodError, req.Method)))
+			return
+		}
+		i.postHandler(logger, inchan, rw, req)
+	})
+	logger.Infof("accepting POST requests to %s%s", i.Address, i.Path)
+	logger.Fatal(http.ListenAndServe(i.Address, nil))
+}
+
+// Handle HTTP POST requests
+func (i *InputConfig) postHandler(logger *logrus.Logger, inchan config.InChan, rw http.ResponseWriter, req *http.Request) {
+	logger.Debugf("Received request")
+
+	var jsonMsg map[string]interface{}
+	dec := json.NewDecoder(req.Body)
+
+	// attempt to decode post body, if it fails, log it.
+	if err := dec.Decode(&jsonMsg); err != nil {
+		logger.Warnf(invalidJsonError, err)
+		logger.Debugf("Invalid JSON: '%s'", req.Body)
+		rw.WriteHeader(http.StatusBadRequest)
+		rw.Write([]byte(fmt.Sprintf(invalidJsonError, err)))
+		return
+	}
+
+	// send the event as it came to us
+	inchan <- logevent.LogEvent{Extra: jsonMsg}
+}

--- a/input/redis/inputredis.go
+++ b/input/redis/inputredis.go
@@ -1,0 +1,137 @@
+package inputredis
+
+import (
+	"encoding/json"
+	"github.com/Sirupsen/logrus"
+	"github.com/tsaikd/gogstash/config"
+	"github.com/tsaikd/gogstash/config/logevent"
+	"github.com/fzzy/radix/redis"
+	"bytes"
+)
+
+// ModuleName is the name used in config file
+const ModuleName = "redis"
+
+const invalidJsonError = "Invalid JSON received from Redis input. Decoder error: %+v"
+
+// InputConfig holds the output configuration json fields
+type InputConfig struct {
+	config.InputConfig
+	Key               string   `json:"key"`
+	Host              string `json:"host"`
+	DataType          string   `json:"data_type,omitempty"` // one of ["list", "channel"] TODO!`
+	Connections 	  int	   `json:"connections"`
+	ReconnectInterval int      `json:"reconnect_interval,omitempty"` // TODO!
+
+	clients []*redis.Client // all configured clients
+}
+
+// DefaultInputConfig returns an InputConfig struct with default values
+func DefaultInputConfig() InputConfig {
+	return InputConfig{
+		InputConfig: config.InputConfig{
+			CommonConfig: config.CommonConfig{
+				Type: ModuleName,
+			},
+		},
+		Key:               "gogstash",
+		DataType:          "list",
+		Connections:	   5,
+		ReconnectInterval: 1,
+	}
+}
+
+// InitHandler initialize the input plugin
+func InitHandler(confraw *config.ConfigRaw) (config.TypeInputConfig, error) {
+	conf := DefaultInputConfig()
+	if err := config.ReflectConfig(confraw, &conf); err != nil {
+		return nil, err
+	}
+
+	if err := conf.initRedisClients(); err != nil {
+		return nil, err
+	}
+
+	return &conf, nil
+}
+
+func (i *InputConfig) closeRedisClients() (err error) {
+	for _, client := range i.clients {
+		client.Close()
+	}
+	i.clients = i.clients[:0]
+	return
+}
+
+// Open connections to redis server
+func (i *InputConfig) initRedisClients() error {
+
+	i.closeRedisClients()
+
+	for j := 0; j <= i.Connections; j++ {
+		if client, err := redis.Dial("tcp", i.Host); err == nil {
+			i.clients = append(i.clients, client)
+		} else {
+			logrus.Fatalf("Redis connection to '%s' failed: %s", i.Host, err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Start wraps the actual function starting the plugin
+func (i *InputConfig) Start() {
+	i.Invoke(i.start)
+}
+
+
+// spawn all input handlers
+func (i *InputConfig) start(logger *logrus.Logger, inchan config.InChan) {
+	for _, client := range i.clients {
+		logger.Debug("Spawning redis input handler")
+		go i.inputHandler(logger, inchan, client)
+	}
+}
+
+// launch redis input handler to listen for incoming messages and publish them on the InChan
+func (i *InputConfig) inputHandler(logger *logrus.Logger, inchan config.InChan, client *redis.Client) {
+	logger.Debugf("Started input handler")
+	for {
+		// wait forever for a message from redis.
+		reply := client.Cmd("blpop", i.Key, 0)
+		if reply.Err != nil {
+			// something bad happened with the blpop?
+			logger.Errorf("Error with redis input client: %+v", reply.Err)
+			break
+		}
+
+		var jsonMsg map[string]interface{}
+
+		msg, err := reply.ListBytes();
+		if err != nil {
+			// I got no idea, but somehow ListBytes gave me an error.
+			logger.Errorf("Error retrieving bytes from redis message: %+v", err)
+			break
+		}
+
+		// we need to use msg[1] because BLPOP returns a tuple of (key,value) where key is
+		// the redis key used to retrieve the message
+		dec := json.NewDecoder(bytes.NewReader(msg[1]))
+
+		// attempt to decode post body, if it fails, log it.
+		if err := dec.Decode(&jsonMsg); err != nil {
+			logger.Errorf(invalidJsonError, err)
+			logger.Debugf("Invalid JSON: '%s'", msg[1])
+			continue
+		}
+
+		// send the event as it came to us
+		inchan <- logevent.LogEvent{Extra: jsonMsg}
+	}
+
+	// Somehow I encountered an error and died. Don't stay dead!
+	// TODO: count errors, and fatalf if error count exceeds retries
+	logger.Errorf("Redis inputHandler thread died, respawning!")
+	go i.inputHandler(logger, inchan, client)
+}

--- a/input/redis/inputredis.go
+++ b/input/redis/inputredis.go
@@ -1,12 +1,12 @@
 package inputredis
 
 import (
+	"bytes"
 	"encoding/json"
 	"github.com/Sirupsen/logrus"
+	"github.com/fzzy/radix/redis"
 	"github.com/tsaikd/gogstash/config"
 	"github.com/tsaikd/gogstash/config/logevent"
-	"github.com/fzzy/radix/redis"
-	"bytes"
 )
 
 // ModuleName is the name used in config file
@@ -17,11 +17,11 @@ const invalidJsonError = "Invalid JSON received from Redis input. Decoder error:
 // InputConfig holds the output configuration json fields
 type InputConfig struct {
 	config.InputConfig
-	Key               string   `json:"key"`
+	Key               string `json:"key"`
 	Host              string `json:"host"`
-	DataType          string   `json:"data_type,omitempty"` // one of ["list", "channel"] TODO!`
-	Connections 	  int	   `json:"connections"`
-	ReconnectInterval int      `json:"reconnect_interval,omitempty"` // TODO!
+	DataType          string `json:"data_type,omitempty"` // one of ["list", "channel"] TODO!`
+	Connections       int    `json:"connections"`
+	ReconnectInterval int    `json:"reconnect_interval,omitempty"` // TODO!
 
 	clients []*redis.Client // all configured clients
 }
@@ -36,7 +36,7 @@ func DefaultInputConfig() InputConfig {
 		},
 		Key:               "gogstash",
 		DataType:          "list",
-		Connections:	   5,
+		Connections:       5,
 		ReconnectInterval: 1,
 	}
 }
@@ -85,7 +85,6 @@ func (i *InputConfig) Start() {
 	i.Invoke(i.start)
 }
 
-
 // spawn all input handlers
 func (i *InputConfig) start(logger *logrus.Logger, inchan config.InChan) {
 	for _, client := range i.clients {
@@ -108,7 +107,7 @@ func (i *InputConfig) inputHandler(logger *logrus.Logger, inchan config.InChan, 
 
 		var jsonMsg map[string]interface{}
 
-		msg, err := reply.ListBytes();
+		msg, err := reply.ListBytes()
 		if err != nil {
 			// I got no idea, but somehow ListBytes gave me an error.
 			logger.Errorf("Error retrieving bytes from redis message: %+v", err)

--- a/modloader/modloader.go
+++ b/modloader/modloader.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tsaikd/gogstash/input/file"
 	"github.com/tsaikd/gogstash/input/http"
 	"github.com/tsaikd/gogstash/input/httplisten"
+	"github.com/tsaikd/gogstash/input/redis"
 	"github.com/tsaikd/gogstash/input/socket"
 	"github.com/tsaikd/gogstash/output/amqp"
 	"github.com/tsaikd/gogstash/output/elastic"
@@ -18,7 +19,6 @@ import (
 	"github.com/tsaikd/gogstash/output/redis"
 	"github.com/tsaikd/gogstash/output/report"
 	"github.com/tsaikd/gogstash/output/stdout"
-	"github.com/tsaikd/gogstash/input/redis"
 )
 
 func init() {

--- a/modloader/modloader.go
+++ b/modloader/modloader.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tsaikd/gogstash/input/exec"
 	"github.com/tsaikd/gogstash/input/file"
 	"github.com/tsaikd/gogstash/input/http"
+	"github.com/tsaikd/gogstash/input/httplisten"
 	"github.com/tsaikd/gogstash/input/socket"
 	"github.com/tsaikd/gogstash/output/amqp"
 	"github.com/tsaikd/gogstash/output/elastic"
@@ -17,6 +18,7 @@ import (
 	"github.com/tsaikd/gogstash/output/redis"
 	"github.com/tsaikd/gogstash/output/report"
 	"github.com/tsaikd/gogstash/output/stdout"
+	"github.com/tsaikd/gogstash/input/redis"
 )
 
 func init() {
@@ -25,7 +27,9 @@ func init() {
 	config.RegistInputHandler(inputdockerstats.ModuleName, inputdockerstats.InitHandler)
 	config.RegistInputHandler(inputfile.ModuleName, inputfile.InitHandler)
 	config.RegistInputHandler(inputhttp.ModuleName, inputhttp.InitHandler)
+	config.RegistInputHandler(httplisten.ModuleName, httplisten.InitHandler)
 	config.RegistInputHandler(inputsocket.ModuleName, inputsocket.InitHandler)
+	config.RegistInputHandler(inputredis.ModuleName, inputredis.InitHandler)
 
 	config.RegistFilterHandler(filteraddfield.ModuleName, filteraddfield.InitHandler)
 	config.RegistFilterHandler(filterjson.ModuleName, filterjson.InitHandler)

--- a/output/elastic/outputelastic.go
+++ b/output/elastic/outputelastic.go
@@ -3,7 +3,14 @@ package outputelastic
 import (
 	"github.com/tsaikd/gogstash/config"
 	"github.com/tsaikd/gogstash/config/logevent"
-	"gopkg.in/olivere/elastic.v3"
+	elastic3 "gopkg.in/olivere/elastic.v3"
+	elastic5 "gopkg.in/olivere/elastic.v5"
+	"net/http"
+	"github.com/Sirupsen/logrus"
+	"io/ioutil"
+	"encoding/json"
+	"github.com/hashicorp/go-version"
+	"golang.org/x/net/context"
 )
 
 const (
@@ -16,10 +23,12 @@ type OutputConfig struct {
 	Index        string `json:"index"`
 	DocumentType string `json:"document_type"`
 	DocumentID   string `json:"document_id"`
+	ElasticVersion string `json:"es_version"` // 3, 5, or auto.
 
 	Sniff bool `json:"sniff"` // find all nodes of your cluster, https://github.com/olivere/elastic/wiki/Sniffing
 
-	client *elastic.Client
+	client interface{} // we'll cast this to the proper client type when we're ready.
+	clientVersion int // private var to hold client version to use after detection
 }
 
 func DefaultOutputConfig() OutputConfig {
@@ -29,19 +38,40 @@ func DefaultOutputConfig() OutputConfig {
 				Type: ModuleName,
 			},
 		},
+		ElasticVersion: "auto",
 	}
 }
 
-func InitHandler(confraw *config.ConfigRaw) (retconf config.TypeOutputConfig, err error) {
+func InitHandler(confraw *config.ConfigRaw, logger *logrus.Logger) (retconf config.TypeOutputConfig, err error) {
 	conf := DefaultOutputConfig()
 	if err = config.ReflectConfig(confraw, &conf); err != nil {
 		return
 	}
 
-	conf.client, err = elastic.NewClient(
-		elastic.SetURL(conf.URL),
-		elastic.SetSniff(conf.Sniff),
-	)
+	switch (conf.ElasticVersion) {
+	case "auto":
+		conf.clientVersion = detectElasticVersion(&conf, logger)
+	case "3":
+		conf.clientVersion = 3
+	case "5":
+		conf.clientVersion = 5
+	default:
+		logger.Fatalf("Invalid config for es_version: expected one of [\"3\",\"5\",\"auto\"] but got: '%v'", conf.ElasticVersion)
+	}
+
+
+	if conf.clientVersion == 3 {
+		conf.client, err = elastic3.NewClient(
+			elastic3.SetURL(conf.URL),
+			elastic3.SetSniff(conf.Sniff),
+		)
+	} else {
+		conf.client, err = elastic5.NewClient(
+			elastic5.SetURL(conf.URL),
+			elastic5.SetSniff(conf.Sniff),
+		)
+	}
+
 	if err != nil {
 		return
 	}
@@ -50,16 +80,57 @@ func InitHandler(confraw *config.ConfigRaw) (retconf config.TypeOutputConfig, er
 	return
 }
 
+func detectElasticVersion(config *OutputConfig, logger *logrus.Logger) int {
+	response, err := http.Get(config.URL)
+	if err != nil {
+		logger.Errorf("Unable to detect contact Elasticsearch to determine version. Error: %+v", err)
+		return 0
+	}
+	defer response.Body.Close()
+	buf, _ := ioutil.ReadAll(response.Body)
+
+	var dest map[string]interface{}
+	json.Unmarshal(buf, &dest)
+
+	// yeah, i'd rather not make a struct just for this.
+	ver, _ := version.NewVersion(dest["version"].(map[string]interface{})["number"].(string))
+
+	v3constraint, _ := version.NewConstraint(">= 2.0.0, < 5.0.0")
+	v5constraint, _ := version.NewConstraint(">= 5.0.0")
+
+	if v3constraint.Check(ver) {
+		logger.Debug("Detected Elasticsearch version 3")
+		return 3
+	} else if v5constraint.Check(ver) {
+		logger.Debug("Detected Elasticsearch version 5")
+		return 5
+	} else {
+		logger.Errorf("Unable to determine Elasticsearch version from version string: '%+v'", ver)
+	}
+
+	return 0
+
+}
+
 func (t *OutputConfig) Event(event logevent.LogEvent) (err error) {
 	index := event.Format(t.Index)
 	doctype := event.Format(t.DocumentType)
 	id := event.Format(t.DocumentID)
 
-	_, err = t.client.Index().
-		Index(index).
-		Type(doctype).
-		Id(id).
-		BodyJson(event).
-		Do()
+	if t.clientVersion == 3 {
+		_, err = t.client.(*elastic3.Client).Index().
+			Index(index).
+			Type(doctype).
+			Id(id).
+			BodyJson(event).
+			Do()
+	} else if t.clientVersion == 5 {
+		_, err = t.client.(*elastic5.Client).Index().
+			Index(index).
+			Type(doctype).
+			Id(id).
+			BodyJson(event).
+			Do(context.TODO())
+	}
 	return
 }

--- a/output/elastic/outputelastic.go
+++ b/output/elastic/outputelastic.go
@@ -95,7 +95,7 @@ func detectElasticVersion(config *OutputConfig, logger *logrus.Logger) int {
 	// yeah, i'd rather not make a struct just for this.
 	ver, _ := version.NewVersion(dest["version"].(map[string]interface{})["number"].(string))
 
-	v3constraint, _ := version.NewConstraint(">= 2.0.0, < 5.0.0")
+	v3constraint, _ := version.NewConstraint(">= 3.0.0, < 5.0.0")
 	v5constraint, _ := version.NewConstraint(">= 5.0.0")
 
 	if v3constraint.Check(ver) {

--- a/output/elastic/outputelastic.go
+++ b/output/elastic/outputelastic.go
@@ -1,16 +1,16 @@
 package outputelastic
 
 import (
+	"encoding/json"
+	"github.com/Sirupsen/logrus"
+	"github.com/hashicorp/go-version"
 	"github.com/tsaikd/gogstash/config"
 	"github.com/tsaikd/gogstash/config/logevent"
+	"golang.org/x/net/context"
 	elastic3 "gopkg.in/olivere/elastic.v3"
 	elastic5 "gopkg.in/olivere/elastic.v5"
-	"net/http"
-	"github.com/Sirupsen/logrus"
 	"io/ioutil"
-	"encoding/json"
-	"github.com/hashicorp/go-version"
-	"golang.org/x/net/context"
+	"net/http"
 )
 
 const (
@@ -19,16 +19,16 @@ const (
 
 type OutputConfig struct {
 	config.OutputConfig
-	URL          string `json:"url"`
-	Index        string `json:"index"`
-	DocumentType string `json:"document_type"`
-	DocumentID   string `json:"document_id"`
+	URL            string `json:"url"`
+	Index          string `json:"index"`
+	DocumentType   string `json:"document_type"`
+	DocumentID     string `json:"document_id"`
 	ElasticVersion string `json:"es_version"` // 3, 5, or auto.
 
 	Sniff bool `json:"sniff"` // find all nodes of your cluster, https://github.com/olivere/elastic/wiki/Sniffing
 
-	client interface{} // we'll cast this to the proper client type when we're ready.
-	clientVersion int // private var to hold client version to use after detection
+	client        interface{} // we'll cast this to the proper client type when we're ready.
+	clientVersion int         // private var to hold client version to use after detection
 }
 
 func DefaultOutputConfig() OutputConfig {
@@ -48,7 +48,7 @@ func InitHandler(confraw *config.ConfigRaw, logger *logrus.Logger) (retconf conf
 		return
 	}
 
-	switch (conf.ElasticVersion) {
+	switch conf.ElasticVersion {
 	case "auto":
 		conf.clientVersion = detectElasticVersion(&conf, logger)
 	case "3":
@@ -58,7 +58,6 @@ func InitHandler(confraw *config.ConfigRaw, logger *logrus.Logger) (retconf conf
 	default:
 		logger.Fatalf("Invalid config for es_version: expected one of [\"3\",\"5\",\"auto\"] but got: '%v'", conf.ElasticVersion)
 	}
-
 
 	if conf.clientVersion == 3 {
 		conf.client, err = elastic3.NewClient(


### PR DESCRIPTION
Documentation/tests to come soon. Just adding this as a PR for now so it's visible in case anyone wants to use it in the meantime.
Feel free to not merge this until the documentation, examples, and tests are ready.

Oh, and I added a `--debug` flag to the app, maybe that wasn't necessary, but I couldn't figure out how debug logs were supposed to be enabled previously.

The Redis input allows you to use Gogstash in a setup similar to this:
- Application does a RPUSH to redis for log statements (an example for NodeJS is to use Winston-Redis as an output). 
This could be instead another Gogstash instance using an HTTP input (included in this changeset) that is writing to redis.
- Gogstash reads from Redis using the redis input and outputs to Elasticsearch

The HTTP input allows you to POST data to Gogstash, and it has a few configurable settings (such as the path you want it listening on, and any headers you might require for auth).
I have not yet added support for the HTTP input to have multiple paths on the same port (i.e. if you listen on port 8081 with path /, you can't have a path /log on port 8081).

In my case, I'm using a Gogstash instance on an edge server with the HTTP input to write to a redis list and a Gogstash instance (on an internal server) to pick up data from the list and write it to Elasticsearch. This allows me to scale my worker instances for resiliency/security.

ES5.x support has been added - it'll autodetect your ES version if possible.

Thanks for Gogstash! 