### PR TITLE
Add support for Socket output

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,4 +191,5 @@ See [output modules](output) for more information
 * [prometheus](output/prometheus)
 * [redis](output/redis)
 * [report](output/report)
+* [socket](output/socket)
 * [stdout](output/stdout)

--- a/output/socket/README.md
+++ b/output/socket/README.md
@@ -1,0 +1,30 @@
+gogstash output socket
+======================
+
+## Synopsis
+
+```
+{
+	"output": [
+		{
+			"type": "socket",
+
+			// Socket type. Must be one of any of the types supported by net.Dial, i.e.: ["udp", "tcp", "unix", "unixpacket"].
+			"socket": "tcp",
+
+			// For TCP, address must have the form `host:port`.
+			// For Unix networks, the address must be a file system path.
+			"address": "localhost:9999"
+		}
+	]
+}
+```
+
+## Details
+
+* type
+	* Must be **"socket"**
+* socket
+	* Socket type supported by [net.Dial](https://godoc.org/net#Dial)
+* address
+	* Address in a format supported by [net.Dial](https://godoc.org/net#Dial)

--- a/output/socket/outputsocket.go
+++ b/output/socket/outputsocket.go
@@ -1,0 +1,68 @@
+package socket
+
+import (
+	"context"
+
+	"github.com/tsaikd/gogstash/config"
+	"github.com/tsaikd/gogstash/config/logevent"
+	"net"
+)
+
+// ModuleName is the name used in config file
+const ModuleName = "socket"
+
+// OutputConfig holds the configuration json fields and internal objects
+type OutputConfig struct {
+	config.OutputConfig
+	Socket       string `json:"socket"`  // Type of socket, must be one of ["tcp", "unix", "unixpacket"].
+	Address      string `json:"address"` // For TCP, address must have the form `host:port`. For Unix networks, the address must be a file system path.
+	outputSocket *net.Conn
+}
+
+// DefaultOutputConfig returns an OutputConfig struct with default values
+func DefaultOutputConfig() OutputConfig {
+	return OutputConfig{
+		OutputConfig: config.OutputConfig{
+			CommonConfig: config.CommonConfig{
+				Type: ModuleName,
+			},
+		},
+	}
+}
+
+// InitHandler initialize the output plugin
+func InitHandler(ctx context.Context, raw *config.ConfigRaw) (config.TypeOutputConfig, error) {
+	conf := DefaultOutputConfig()
+	if err := config.ReflectConfig(raw, &conf); err != nil {
+		return nil, err
+	}
+
+	// init Socket
+	conn, err := net.Dial(conf.Socket, conf.Address)
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		select {
+		case <-ctx.Done():
+			conn.Close()
+		}
+	}()
+
+	conf.outputSocket = &conn
+
+	return &conf, nil
+}
+
+// Output event
+func (t *OutputConfig) Output(ctx context.Context, event logevent.LogEvent) error {
+	b, err := event.MarshalJSON()
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	if _, err := (*t.outputSocket).Write(b); err != nil {
+		return err
+	}
+	return nil
+}

--- a/output/socket/outputsocket_test.go
+++ b/output/socket/outputsocket_test.go
@@ -1,0 +1,63 @@
+package socket
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stvp/go-udp-testing"
+	"github.com/tsaikd/gogstash/config"
+	"github.com/tsaikd/gogstash/config/logevent"
+	"math/rand"
+)
+
+var (
+	logger = config.Logger
+)
+
+func init() {
+	logger.Level = logrus.DebugLevel
+	config.RegistOutputHandler(ModuleName, InitHandler)
+}
+
+func Test_output_report_module(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+	require := require.New(t)
+	require.NotNil(require)
+
+	udp.SetAddr(":9876")
+	// This is needed to make sure that UDP Listener listens for data a bit longer, otherwise it will quit after a millisecond
+	udp.Timeout = 5 * time.Second
+
+	ctx := context.Background()
+	conf, err := config.LoadFromYAML([]byte(strings.TrimSpace(`
+debugch: true
+output:
+  - type: socket
+    socket: udp
+    address: localhost:9876
+	`)))
+	require.NoError(err)
+	require.NoError(conf.Start(ctx))
+
+	var messages []logevent.LogEvent
+	var expected []string
+	for _, m := range []string{"one", "two", "three", "four", "five", "six", "seven"} {
+		msg := logevent.LogEvent{Message: m}
+		messages = append(messages, msg)
+		json, _ := msg.MarshalJSON()
+		expected = append(expected, string(json)+"\n")
+	}
+
+	udp.ShouldReceiveAll(t, expected, func() {
+		for _, m := range messages {
+			conf.TestInputEvent(m)
+			time.Sleep(time.Duration(rand.Intn(1000)) * time.Millisecond)
+		}
+	})
+}


### PR DESCRIPTION
Add support for output to a network socket.  Useful for being able to parse/clean up logs collected via `file` or `exec` inputs and forwarded to a local custom agent via a network socket.