### PR TITLE
add filter/cond and output/cond

### DIFF
--- a/config/filter.go
+++ b/config/filter.go
@@ -36,21 +36,26 @@ func RegistFilterHandler(name string, handler FilterHandler) {
 	mapFilterHandler[name] = handler
 }
 
-func (t *Config) getFilters() (filters []TypeFilterConfig, err error) {
+// GetFilters get filters from config
+func GetFilters(ctx context.Context, filterRaw []ConfigRaw) (filters []TypeFilterConfig, err error) {
 	var filter TypeFilterConfig
-	for _, raw := range t.FilterRaw {
+	for _, raw := range filterRaw {
 		handler, ok := mapFilterHandler[raw["type"].(string)]
 		if !ok {
 			return filters, ErrorUnknownFilterType1.New(nil, raw["type"])
 		}
 
-		if filter, err = handler(t.ctx, &raw); err != nil {
+		if filter, err = handler(ctx, &raw); err != nil {
 			return filters, ErrorInitFilterFailed1.New(err, raw)
 		}
 
 		filters = append(filters, filter)
 	}
 	return
+}
+
+func (t *Config) getFilters() (filters []TypeFilterConfig, err error) {
+	return GetFilters(t.ctx, t.FilterRaw)
 }
 
 func (t *Config) startFilters() (err error) {

--- a/config/util.go
+++ b/config/util.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"reflect"
 	"regexp"
+	"strings"
 
 	"github.com/icza/dyno"
 	"github.com/tsaikd/KDGoLib/logutil"
@@ -29,6 +30,24 @@ func ReflectConfig(confraw *ConfigRaw, conf interface{}) (err error) {
 	formatReflect(rv)
 
 	return
+}
+
+// GetFromObject obtaining value from specified field recursively
+func GetFromObject(obj map[string]interface{}, field string) interface{} {
+	fieldSplits := strings.Split(field, ".")
+	if len(fieldSplits) < 2 {
+		if value, ok := obj[field]; ok {
+			return value
+		}
+		return nil
+	}
+
+	switch child := obj[fieldSplits[0]].(type) {
+	case map[string]interface{}:
+		return GetFromObject(child, strings.Join(fieldSplits[1:], "."))
+	default:
+		return nil
+	}
 }
 
 func formatReflect(rv reflect.Value) {

--- a/filter/cond/README.md
+++ b/filter/cond/README.md
@@ -1,0 +1,34 @@
+gogstash cond filter module
+=============================
+
+Condition syntax depends `govaluate`:
+
+* https://github.com/Knetic/govaluate
+
+Only boolean `true` for the result value is considered to be eligible.
+
+## Synopsis
+
+```yaml
+filter:
+  - type: cond
+    # (required) condition need to be satisfied
+    condition: "level == 'ERROR'"
+    # (required) filter config
+    filter:
+      - type: add_field
+        key: foo
+        value: bar
+```
+
+```yaml
+filter:
+  - type: cond
+    # (required) condition need to be satisfied
+    condition: "[nginx.access.url] ? [nginx.access.url] =~ '^/api/'"
+    # (required) filter config
+    filter:
+      - type: add_field
+        key: foo
+        value: bar
+```

--- a/filter/cond/filtercond.go
+++ b/filter/cond/filtercond.go
@@ -1,0 +1,93 @@
+package filtercond
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Knetic/govaluate"
+	"github.com/tsaikd/gogstash/config"
+	"github.com/tsaikd/gogstash/config/logevent"
+)
+
+// ModuleName is the name used in config file
+const ModuleName = "cond"
+
+// ErrorTag tag added to event when process geoip2 failed
+const ErrorTag = "gogstash_filter_cond_error"
+
+// FilterConfig holds the configuration json fields and internal objects
+type FilterConfig struct {
+	config.FilterConfig
+
+	Condition  string             `json:"condition"` // condition need to be satisfied
+	FilterRaw  []config.ConfigRaw `json:"filter"`    // filters when satisfy the condition
+	filters    []config.TypeFilterConfig
+	expression *govaluate.EvaluableExpression
+}
+
+// EventParameters pack event's parameters by member function `Get` access
+type EventParameters struct {
+	Event *logevent.LogEvent
+}
+
+// Get obtaining value from event's specified field recursively
+func (ep *EventParameters) Get(field string) (interface{}, error) {
+	if strings.IndexRune(field, '.') < 0 {
+		// no nest fields
+		return ep.Event.Get(field), nil
+	}
+	return config.GetFromObject(ep.Event.Extra, field), nil
+}
+
+// DefaultFilterConfig returns an FilterConfig struct with default values
+func DefaultFilterConfig() FilterConfig {
+	return FilterConfig{
+		FilterConfig: config.FilterConfig{
+			CommonConfig: config.CommonConfig{
+				Type: ModuleName,
+			},
+		},
+	}
+}
+
+// InitHandler initialize the filter plugin
+func InitHandler(ctx context.Context, raw *config.ConfigRaw) (config.TypeFilterConfig, error) {
+	conf := DefaultFilterConfig()
+	err := config.ReflectConfig(raw, &conf)
+	if err != nil {
+		return nil, err
+	}
+	if conf.Condition == "" {
+		config.Logger.Warn("filter cond config condition empty, ignored")
+		return &conf, nil
+	}
+	conf.filters, err = config.GetFilters(ctx, conf.FilterRaw)
+	if err != nil {
+		return nil, err
+	}
+	if len(conf.filters) <= 0 {
+		config.Logger.Warn("filter cond config filters empty, ignored")
+		return &conf, nil
+	}
+	conf.expression, err = govaluate.NewEvaluableExpression(conf.Condition)
+	return &conf, nil
+}
+
+// Event the main filter event
+func (f *FilterConfig) Event(ctx context.Context, event logevent.LogEvent) logevent.LogEvent {
+	if f.expression != nil {
+		ep := EventParameters{Event: &event}
+		ret, err := f.expression.Eval(&ep)
+		if err != nil {
+			config.Logger.Error(err)
+			event.AddTag(ErrorTag)
+			return event
+		}
+		if ok, _ := ret.(bool); ok {
+			for _, filter := range f.filters {
+				event = filter.Event(ctx, event)
+			}
+		}
+	}
+	return event
+}

--- a/filter/cond/filtercond_test.go
+++ b/filter/cond/filtercond_test.go
@@ -1,0 +1,85 @@
+package filtercond
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tsaikd/gogstash/config"
+	"github.com/tsaikd/gogstash/config/logevent"
+	"github.com/tsaikd/gogstash/filter/addfield"
+)
+
+var (
+	logger = config.Logger
+)
+
+func init() {
+	logger.Level = logrus.DebugLevel
+	config.RegistFilterHandler(filteraddfield.ModuleName, filteraddfield.InitHandler)
+	config.RegistFilterHandler(ModuleName, InitHandler)
+}
+
+func Test_filter_cond_module(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+	require := require.New(t)
+	require.NotNil(require)
+
+	ctx := context.Background()
+	conf, err := config.LoadFromYAML([]byte(strings.TrimSpace(`
+debugch: true
+filter:
+  - type: cond
+    condition: "level == 'ERROR'"
+    filter:
+      - type: add_field
+        key: foo
+        value: bar
+	`)))
+	require.NoError(err)
+	require.NoError(conf.Start(ctx))
+
+	timestamp := time.Now()
+	expectedEvent1 := logevent.LogEvent{
+		Timestamp: timestamp,
+		Message:   "filter test message 1",
+		Extra: map[string]interface{}{
+			"level": "ERROR",
+			"foo":   "bar",
+		},
+	}
+	expectedEvent2 := logevent.LogEvent{
+		Timestamp: timestamp,
+		Message:   "filter test message 2",
+		Extra: map[string]interface{}{
+			"level": "WARN",
+		},
+	}
+
+	conf.TestInputEvent(logevent.LogEvent{
+		Timestamp: timestamp,
+		Message:   "filter test message 1",
+		Extra: map[string]interface{}{
+			"level": "ERROR",
+		},
+	})
+	if event, err := conf.TestGetOutputEvent(300 * time.Millisecond); assert.NoError(err) {
+		require.Equal(expectedEvent1, event)
+	}
+
+	conf.TestInputEvent(logevent.LogEvent{
+		Timestamp: timestamp,
+		Message:   "filter test message 2",
+		Extra: map[string]interface{}{
+			"level": "WARN",
+		},
+	})
+	if event, err := conf.TestGetOutputEvent(300 * time.Millisecond); assert.NoError(err) {
+		require.Equal(expectedEvent2, event)
+	}
+}

--- a/modloader/modloader.go
+++ b/modloader/modloader.go
@@ -3,6 +3,7 @@ package modloader
 import (
 	"github.com/tsaikd/gogstash/config"
 	"github.com/tsaikd/gogstash/filter/addfield"
+	"github.com/tsaikd/gogstash/filter/cond"
 	"github.com/tsaikd/gogstash/filter/date"
 	"github.com/tsaikd/gogstash/filter/geoip2"
 	"github.com/tsaikd/gogstash/filter/gonx"
@@ -20,6 +21,7 @@ import (
 	"github.com/tsaikd/gogstash/input/redis"
 	"github.com/tsaikd/gogstash/input/socket"
 	"github.com/tsaikd/gogstash/output/amqp"
+	"github.com/tsaikd/gogstash/output/cond"
 	"github.com/tsaikd/gogstash/output/elastic"
 	"github.com/tsaikd/gogstash/output/email"
 	"github.com/tsaikd/gogstash/output/prometheus"
@@ -39,6 +41,7 @@ func init() {
 	config.RegistInputHandler(inputsocket.ModuleName, inputsocket.InitHandler)
 
 	config.RegistFilterHandler(filteraddfield.ModuleName, filteraddfield.InitHandler)
+	config.RegistFilterHandler(filtercond.ModuleName, filtercond.InitHandler)
 	config.RegistFilterHandler(filterdate.ModuleName, filterdate.InitHandler)
 	config.RegistFilterHandler(filtergeoip2.ModuleName, filtergeoip2.InitHandler)
 	config.RegistFilterHandler(filtergonx.ModuleName, filtergonx.InitHandler)
@@ -49,6 +52,7 @@ func init() {
 	config.RegistFilterHandler(filtergrok.ModuleName, filtergrok.InitHandler)
 
 	config.RegistOutputHandler(outputamqp.ModuleName, outputamqp.InitHandler)
+	config.RegistOutputHandler(outputcond.ModuleName, outputcond.InitHandler)
 	config.RegistOutputHandler(outputelastic.ModuleName, outputelastic.InitHandler)
 	config.RegistOutputHandler(outputemail.ModuleName, outputemail.InitHandler)
 	config.RegistOutputHandler(outputprometheus.ModuleName, outputprometheus.InitHandler)

--- a/output/cond/README.md
+++ b/output/cond/README.md
@@ -1,0 +1,27 @@
+gogstash cond elastic
+=======================
+
+Condition syntax is same as [`filter/cond`](../../filter/cond).
+
+## Synopsis
+
+```
+{
+	"output": [
+		{
+			"type": "cond",
+
+			// (required)
+			"condition": "level == 'ERROR'",
+
+			// (required)
+			"output": [
+
+				// output config
+				{ "type": "stdout" }
+
+			]
+		}
+	]
+}
+```

--- a/output/cond/outputcond_test.go
+++ b/output/cond/outputcond_test.go
@@ -1,0 +1,69 @@
+package outputcond
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tsaikd/gogstash/config"
+	"github.com/tsaikd/gogstash/config/logevent"
+	"github.com/tsaikd/gogstash/output/stdout"
+)
+
+var (
+	logger = config.Logger
+)
+
+func init() {
+	logger.Level = logrus.DebugLevel
+	config.RegistOutputHandler(outputstdout.ModuleName, outputstdout.InitHandler)
+	config.RegistOutputHandler(ModuleName, InitHandler)
+}
+
+func Test_output_cond_module(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+	require := require.New(t)
+	require.NotNil(require)
+
+	ctx := context.Background()
+	conf, err := config.LoadFromYAML([]byte(strings.TrimSpace(`
+debugch: true
+output:
+  - type: cond
+    condition: "level == 'ERROR'"
+    output:
+      - type: stdout
+	`)))
+	require.NoError(err)
+	require.NoError(conf.Start(ctx))
+
+	conf.TestInputEvent(logevent.LogEvent{
+		Timestamp: time.Now(),
+		Message:   "outputstdout test message",
+		Extra: map[string]interface{}{
+			"level": "ERROR",
+			"foo":   "bar",
+		},
+	})
+
+	if event, err := conf.TestGetOutputEvent(300 * time.Millisecond); assert.NoError(err) {
+		require.Equal("outputstdout test message", event.Message)
+	}
+
+	conf.TestInputEvent(logevent.LogEvent{
+		Timestamp: time.Now(),
+		Message:   "outputstdout test message",
+		Extra: map[string]interface{}{
+			"level": "WARN",
+		},
+	})
+
+	if event, err := conf.TestGetOutputEvent(300 * time.Millisecond); assert.NoError(err) {
+		require.Equal("outputstdout test message", event.Message)
+	}
+}


### PR DESCRIPTION
Hi, I think this could help us to do more complex consumption for events.

Add `filter/cond` and `output/cond` implements the sequence control for event's filters and outputs.

a simple config:
```yml
input:
  - type: httplisten
    address: '0.0.0.0:8081'
    path: '/log'
filter:
  - type: add_field
    key: instance_id
    value: '123456'
  - type: cond
    condition: "[nginx.access.url] != nil ? [nginx.access.url] =~ '^/api/'"
    filter:
      - type: add_field
        key: controller
        value: api
output:
  - type: cond
    condition: "info == 'ERROR'"
    output:
      - type: stdout
```