### PR TITLE
add built-in functions for cond

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ See [input modules](input) for more information
 See [filter modules](filter) for more information
 
 * [add field](filter/addfield)
+* [cond](filter/cond)
 * [date](filter/date)
 * [geoip2](filter/geoip2)
 * [gonx](filter/gonx)
@@ -186,6 +187,7 @@ See [filter modules](filter) for more information
 See [output modules](output) for more information
 
 * [amqp](output/amqp)
+* [cond](output/cond)
 * [elastic](output/elastic)
 * [email](output/email)
 * [prometheus](output/prometheus)

--- a/filter/cond/README.md
+++ b/filter/cond/README.md
@@ -7,6 +7,12 @@ Condition syntax depends `govaluate`:
 
 Only boolean `true` for the result value is considered to be eligible.
 
+Built-in functions:
+
+* `empty()` Checks if the argument is `nil`
+* `strlen()` Returns the string argument's length
+* `rand()` Returns a pseudo-random number in `[0.0,1.0)` as a float64
+
 ## Synopsis
 
 ```yaml
@@ -25,7 +31,7 @@ filter:
 filter:
   - type: cond
     # (required) condition need to be satisfied
-    condition: "[nginx.access.url] ? [nginx.access.url] =~ '^/api/'"
+    condition: "([nginx.access.url] ?? '') =~ '^/api/'"
     # (required) filter config
     filter:
       - type: add_field

--- a/output/cond/outputcond.go
+++ b/output/cond/outputcond.go
@@ -53,23 +53,7 @@ func InitHandler(ctx context.Context, raw *config.ConfigRaw) (config.TypeOutputC
 		config.Logger.Warn("output cond config outputs empty, ignored")
 		return &conf, nil
 	}
-	functions := map[string]govaluate.ExpressionFunction{
-		"Get": func(args ...interface{}) (interface{}, error) {
-			if len(args) <= 1 {
-				return nil, nil
-			}
-			obj := args[0].(map[string]interface{})
-			if obj == nil {
-				return nil, nil
-			}
-			field := args[1].(string)
-			if field != "" {
-				return config.GetFromObject(obj, field), nil
-			}
-			return nil, nil
-		},
-	}
-	conf.expression, err = govaluate.NewEvaluableExpressionWithFunctions(conf.Condition, functions)
+	conf.expression, err = govaluate.NewEvaluableExpressionWithFunctions(conf.Condition, filtercond.GetBuiltInFunctions())
 	return &conf, nil
 }
 

--- a/output/cond/outputcond.go
+++ b/output/cond/outputcond.go
@@ -53,7 +53,7 @@ func InitHandler(ctx context.Context, raw *config.ConfigRaw) (config.TypeOutputC
 		config.Logger.Warn("output cond config outputs empty, ignored")
 		return &conf, nil
 	}
-	conf.expression, err = govaluate.NewEvaluableExpressionWithFunctions(conf.Condition, filtercond.GetBuiltInFunctions())
+	conf.expression, err = govaluate.NewEvaluableExpressionWithFunctions(conf.Condition, filtercond.BuiltInFunctions)
 	return &conf, nil
 }
 


### PR DESCRIPTION
Hi, 

This time I add some built-in functions for cond module:

* `empty()` Checks if the argument is `nil`
* `strlen()` Returns the string argument's length
* `rand()` Returns a pseudo-random number in `[0.0,1.0)` as a float64

This may help us to achieve more kinds of jobs.
For example, we can do output sample here by using `rand() > 0.5`

BTW, I update the README for previous typo in #40.