### PR TITLE
Add input redis blocking timeout option

### DIFF
--- a/input/redis/README.md
+++ b/input/redis/README.md
@@ -16,6 +16,9 @@ input:
 
     # maximum number of socket connections, default: 10
     connections: 10
+
+    # (optional) BLPOP blocking timeout, default: "600s"
+    blocking_timeout: "600s"
 ```
 
 ## WARNING


### PR DESCRIPTION
Sometimes, if we haven't data keep going into redis, and we want to restart gogstash gracefully by send `SIGINT`, it will blocked in `BLPOP` command instead of return error immediately.

So I want to make an option for the `BLPOP` blocking timeout in redis input.