### PR TITLE
Update filter date supports joda time format

### DIFF
--- a/filter/date/filterdate.go
+++ b/filter/date/filterdate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/tengattack/jodatime"
 	"github.com/tsaikd/gogstash/config"
 	"github.com/tsaikd/gogstash/config/goglog"
 	"github.com/tsaikd/gogstash/config/logevent"
@@ -21,6 +22,7 @@ type FilterConfig struct {
 
 	Format string `json:"format"` // date parse format
 	Source string `json:"source"` // source message field name
+	Joda   bool   `json:"joda"`   // whether using joda time format
 }
 
 // DefaultFilterConfig returns an FilterConfig struct with default values
@@ -48,7 +50,15 @@ func InitHandler(ctx context.Context, raw *config.ConfigRaw) (config.TypeFilterC
 
 // Event the main filter event
 func (f *FilterConfig) Event(ctx context.Context, event logevent.LogEvent) logevent.LogEvent {
-	timestamp, err := time.Parse(f.Format, event.GetString(f.Source))
+	var (
+		timestamp time.Time
+		err       error
+	)
+	if f.Joda {
+		timestamp, err = jodatime.Parse(f.Format, event.GetString(f.Source))
+	} else {
+		timestamp, err = time.Parse(f.Format, event.GetString(f.Source))
+	}
 	if err != nil {
 		event.AddTag(ErrorTag)
 		goglog.Logger.Error(err)

--- a/filter/date/filterdate_test.go
+++ b/filter/date/filterdate_test.go
@@ -56,3 +56,42 @@ filter:
 		require.Equal(expectedEvent, event)
 	}
 }
+
+func Test_filter_date_module_joda(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+	require := require.New(t)
+	require.NotNil(require)
+
+	ctx := context.Background()
+	conf, err := config.LoadFromYAML([]byte(strings.TrimSpace(`
+debugch: true
+filter:
+  - type: date
+    format: "YYYY-MM-dd HH:mm:ss,SSS"
+    source: time_local
+    joda: true
+	`)))
+	require.NoError(err)
+	require.NoError(conf.Start(ctx))
+
+	timestamp, err := time.Parse("2006-01-02T15:04:05.000Z", "2018-09-19T19:50:26.208Z")
+	require.NoError(err)
+
+	expectedEvent := logevent.LogEvent{
+		Timestamp: timestamp,
+		Extra: map[string]interface{}{
+			"time_local": "2018-09-19 19:50:26,208",
+		},
+	}
+
+	conf.TestInputEvent(logevent.LogEvent{
+		Extra: map[string]interface{}{
+			"time_local": "2018-09-19 19:50:26,208",
+		},
+	})
+
+	if event, err := conf.TestGetOutputEvent(300 * time.Millisecond); assert.NoError(err) {
+		require.Equal(expectedEvent, event)
+	}
+}


### PR DESCRIPTION
Since go doesn't support fractional seconds in arbitrary format, but only starts with `.`:
https://github.com/golang/go/issues/6189

We need have a way to parse different kinds of time string:
* `2013-08-19 22:56:01,234` https://github.com/golang/go/issues/6189
* `20180724-101112-111` https://github.com/golang/go/issues/27746