### PR TITLE
Add config workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ output:
 * Configure for nginx.yml with gonx filter (example)
 
 ```yml
+chsize: 1000
+workers: 2
+
 input:
   - type: redis
     host: redis.server:6379

--- a/cmd/module.go
+++ b/cmd/module.go
@@ -15,6 +15,12 @@ var (
 		Usage:   "Path to configuration file, default search path: config.json, config.yml",
 		EnvVar:  "CONFIG",
 	}
+	flagFollower = &cobrather.BoolFlag{
+		Name:    "follower",
+		Default: false,
+		Usage:   "golang follower mode",
+		EnvVar:  "FOLLOWER",
+	}
 	flagDebug = &cobrather.BoolFlag{
 		Name:    "debug",
 		Default: false,
@@ -38,10 +44,11 @@ var Module = &cobrather.Module{
 	},
 	Flags: []cobrather.Flag{
 		flagConfig,
+		flagFollower,
 		flagDebug,
 		flagPProf,
 	},
 	RunE: func(ctx context.Context, cmd *cobra.Command, args []string) error {
-		return gogstash(ctx, flagConfig.String(), flagDebug.Bool(), flagPProf.String())
+		return gogstash(ctx, flagConfig.String(), flagFollower.Bool(), flagDebug.Bool(), flagPProf.String())
 	},
 }

--- a/cmd/worker_unix.go
+++ b/cmd/worker_unix.go
@@ -1,0 +1,17 @@
+// +build !windows
+
+package cmd
+
+import (
+	"os"
+	"syscall"
+)
+
+func startWorker() (int, error) {
+	execSpec := &syscall.ProcAttr{
+		Env:   os.Environ(),
+		Files: []uintptr{os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd()},
+	}
+	args := append(os.Args, "--follower")
+	return syscall.ForkExec(os.Args[0], args, execSpec)
+}

--- a/cmd/worker_windows.go
+++ b/cmd/worker_windows.go
@@ -1,0 +1,22 @@
+// +build windows
+
+package cmd
+
+import (
+	"os"
+	"syscall"
+)
+
+func startWorker() (int, error) {
+	execSpec := &syscall.ProcAttr{
+		Env:   os.Environ(),
+		Files: []uintptr{os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd()},
+	}
+	args := append(os.Args, "--follower")
+	pid, handle, err := syscall.StartProcess(os.Args[0], args, execSpec)
+	if err == nil {
+		// succeed
+		syscall.CloseHandle(syscall.Handle(handle))
+	}
+	return pid, err
+}

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,9 @@ type Config struct {
 	// channel size: chInFilter, chFilterOut, chOutDebug
 	ChannelSize int `json:"chsize,omitempty" yaml:"chsize"`
 
+	// workers number, defaults to 1
+	Workers int `json:"workers,omitempty" yaml:"workers"`
+
 	// enable debug channel, used for testing
 	DebugChannel bool `json:"debugch,omitempty" yaml:"debugch"`
 
@@ -46,6 +49,7 @@ type Config struct {
 
 var defaultConfig = Config{
 	ChannelSize: 100,
+	Workers:     1,
 }
 
 // MsgChan message channel type
@@ -97,6 +101,10 @@ func initConfig(config *Config) {
 	if config.ChannelSize < 1 {
 		config.ChannelSize = defaultConfig.ChannelSize
 	}
+	if config.Workers < 1 {
+		config.Workers = defaultConfig.Workers
+	}
+
 	config.chInFilter = make(MsgChan, config.ChannelSize)
 	config.chFilterOut = make(MsgChan, config.ChannelSize)
 	if config.DebugChannel {


### PR DESCRIPTION
Add the workers config to increase CPU usage, since there only one concurrent thread for filter & output.

In real, it can boost up 2x ~ 3x speed for index rate in elasticsearch. 