### PR TITLE
Update input lorem with more options

### DIFF
--- a/input/lorem/README.md
+++ b/input/lorem/README.md
@@ -14,6 +14,22 @@ input:
     # duration to generate lorem, set 0 to generate forever, default: 30s
     duration: "30s"
 
-    # send empty messages without any lorem text, default: false
+    # (optional) message format in go text/template
+    # support functions:
+    #   `TimeFormat(layout string) string`
+    #   `Word(min, max int) string`
+    #   `Sentence(min, max int) string`
+    #   `Paragraph(min, max int) string`
+    #   `Email() string`
+    #   `Host() string`
+    #   `Url() string`
+    # eg. '{{.TimeFormat "20060102-150405.000"}}|ERROR|{{.Sentence 1 5}}' =>
+    #   '20180921-173749.186|ERROR|Valetudinis tria cura cognitionis.'
+    format: '{{.Sentence 1 5}}'
+
+    # (optional) send empty messages without any lorem text, default: false
     empty: false
+
+    # (optional) event extra fields, default: nil
+    #fields:
 ```

--- a/input/lorem/inputlorem.go
+++ b/input/lorem/inputlorem.go
@@ -1,8 +1,13 @@
 package inputlorem
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"text/template"
 	"time"
+
+	"github.com/tsaikd/gogstash/config/goglog"
 
 	lorem "github.com/drhodes/golorem"
 	"github.com/tsaikd/gogstash/config"
@@ -19,7 +24,54 @@ type InputConfig struct {
 	Worker   int    `json:"worker,omitempty"`   // worker count to generate lorem, default: 1
 	Duration string `json:"duration,omitempty"` // duration to generate lorem, set 0 to generate forever, default: 30s
 	duration time.Duration
-	Empty    bool `json:"empty,omitempty"` // send empty messages without any lorem text, default: false
+
+	// format event message using go text/template, defualt: {{.Sentence 1 5}}
+	// support functions:
+	//   `TimeFormat(layout string) string`
+	//   `Word(min, max int) string`
+	//   `Sentence(min, max int) string`
+	//   `Paragraph(min, max int) string`
+	//   `Email() string`
+	//   `Host() string`
+	//   `Url() string`
+	Format string                 `json:"format,omitempty"`
+	Fields map[string]interface{} `json:"fields,omitempty"` // event extra fields
+	Empty  bool                   `json:"empty,omitempty"`  // send empty messages without any lorem text, default: false
+
+	template *template.Template
+}
+
+type loremTemplate struct {
+	tpl       *template.Template
+	timestamp time.Time
+}
+
+func (t *loremTemplate) TimeFormat(layout string) string {
+	return t.timestamp.Format(layout)
+}
+
+func (t *loremTemplate) Word(min, max int) string {
+	return lorem.Word(min, max)
+}
+
+func (t *loremTemplate) Sentence(min, max int) string {
+	return lorem.Sentence(min, max)
+}
+
+func (t *loremTemplate) Paragraph(min, max int) string {
+	return lorem.Paragraph(min, max)
+}
+
+func (t *loremTemplate) Email() string {
+	return lorem.Email()
+}
+
+func (t *loremTemplate) Host() string {
+	return lorem.Host()
+}
+
+func (t *loremTemplate) Url() string {
+	return lorem.Url()
 }
 
 // DefaultInputConfig returns an InputConfig struct with default values
@@ -33,8 +85,15 @@ func DefaultInputConfig() InputConfig {
 		Worker:   1,
 		Duration: "30s",
 		duration: 30 * time.Second,
+		Format:   "{{.Sentence 1 5}}",
+		template: nil,
 	}
 }
+
+// errors
+var (
+	ErrNoMessageFormat = errors.New("no message format for lorem input")
+)
 
 // InitHandler initialize the input plugin
 func InitHandler(ctx context.Context, raw *config.ConfigRaw) (config.TypeInputConfig, error) {
@@ -50,6 +109,15 @@ func InitHandler(ctx context.Context, raw *config.ConfigRaw) (config.TypeInputCo
 
 	if conf.duration, err = time.ParseDuration(conf.Duration); err != nil {
 		return nil, err
+	}
+
+	if conf.Format != "" {
+		conf.template, err = template.New("gogstash-input-lorem").Parse(conf.Format)
+		if err != nil {
+			return nil, err
+		}
+	} else if !conf.Empty {
+		return nil, ErrNoMessageFormat
 	}
 
 	return &conf, nil
@@ -87,13 +155,28 @@ func (t *InputConfig) exec(ctx context.Context, msgChan chan<- logevent.LogEvent
 					Timestamp: time.Now(),
 				}
 			} else {
-				msgChan <- logevent.LogEvent{
-					Timestamp: time.Now(),
-					Message:   lorem.Sentence(1, 5),
-					Extra: map[string]interface{}{
-						"loremurl": lorem.Url(),
-					},
+				timestamp := time.Now()
+				tpl := &loremTemplate{tpl: t.template, timestamp: timestamp}
+				message := bytes.Buffer{}
+				err := tpl.tpl.Execute(&message, tpl)
+				if err != nil {
+					goglog.Logger.Errorf("input lorem template error: %v", err)
 				}
+				event := logevent.LogEvent{
+					Timestamp: time.Now(),
+					Message:   message.String(),
+				}
+				if t.Fields != nil {
+					// copy map values
+					event.Extra = make(map[string]interface{})
+					for k, v := range t.Fields {
+						event.Extra[k] = v
+						if err != nil {
+							goglog.Logger.Errorf("input lorem copy fields error: %v", err)
+						}
+					}
+				}
+				msgChan <- event
 			}
 		}
 	}

--- a/input/lorem/inputlorem_test.go
+++ b/input/lorem/inputlorem_test.go
@@ -44,3 +44,59 @@ input:
 		require.WithinDuration(start, event.Timestamp, 300*time.Millisecond)
 	}
 }
+
+func Test_input_lorem_module_format(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+	require := require.New(t)
+	require.NotNil(require)
+
+	ctx := context.Background()
+	conf, err := config.LoadFromYAML([]byte(strings.TrimSpace(`
+debugch: true
+input:
+  - type: lorem
+    worker: 1
+    format: '{{.TimeFormat "20060102"}}|{{.Sentence 1 5}}'
+    duration: "1s"
+	`)))
+	require.NoError(err)
+	start := time.Now()
+	require.NoError(conf.Start(ctx))
+
+	time.Sleep(500 * time.Millisecond)
+	if event, err := conf.TestGetOutputEvent(100 * time.Millisecond); assert.NoError(err) {
+		require.WithinDuration(start, event.Timestamp, 300*time.Millisecond)
+		require.Equal(start.Format("20060102"), strings.SplitN(event.Message, "|", 2)[0])
+	}
+}
+
+func Test_input_lorem_module_fields(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+	require := require.New(t)
+	require.NotNil(require)
+
+	ctx := context.Background()
+	conf, err := config.LoadFromYAML([]byte(strings.TrimSpace(`
+debugch: true
+input:
+  - type: lorem
+    worker: 1
+    duration: "1s"
+    fields:
+      host: host1
+      prospector:
+        type: log
+	`)))
+	require.NoError(err)
+	start := time.Now()
+	require.NoError(conf.Start(ctx))
+
+	time.Sleep(500 * time.Millisecond)
+	if event, err := conf.TestGetOutputEvent(100 * time.Millisecond); assert.NoError(err) {
+		require.WithinDuration(start, event.Timestamp, 300*time.Millisecond)
+		require.Equal("host1", event.GetString("host"))
+		require.Equal("log", event.GetString("prospector.type"))
+	}
+}


### PR DESCRIPTION
I add some options to lorem make it can simulate various event source:

```yml
    # (optional) message format in go text/template
    # support functions:
    #   `TimeFormat(layout string) string`
    #   `Word(min, max int) string`
    #   `Sentence(min, max int) string`
    #   `Paragraph(min, max int) string`
    #   `Email() string`
    #   `Host() string`
    #   `Url() string`
    # eg. '{{.TimeFormat "20060102-150405.000"}}|ERROR|{{.Sentence 1 5}}' =>
    #   '20180921-173749.186|ERROR|Valetudinis tria cura cognitionis.'
    format: '{{.Sentence 1 5}}'

    # (optional) event extra fields, default: nil
    #fields:
```