### PR TITLE
Add worker management

### DIFF
--- a/cmd/gogstash.go
+++ b/cmd/gogstash.go
@@ -41,14 +41,8 @@ func gogstash(
 		return err
 	}
 
-	if !follower {
-		for i := 1; i < conf.Workers; i++ {
-			pid, err := startWorker()
-			if err != nil {
-				return err
-			}
-			goglog.Logger.Infof("worker started: %d", pid)
-		}
+	if conf.Workers > 0 && !follower {
+		return startWorkers(ctx, conf.Workers)
 	}
 
 	if err = conf.Start(ctx); err != nil {

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -12,7 +12,10 @@ func waitSignals(ctx context.Context) error {
 	osSignalChan := make(chan os.Signal, 1)
 	signal.Notify(osSignalChan, os.Interrupt, os.Kill)
 
-	sig := <-osSignalChan
-	goglog.Logger.Info(sig)
+	select {
+	case <-ctx.Done():
+	case sig := <-osSignalChan:
+		goglog.Logger.Info(sig)
+	}
 	return nil
 }

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"os/signal"
+
+	"github.com/tsaikd/gogstash/config/goglog"
+)
+
+func waitSignals(ctx context.Context) error {
+	osSignalChan := make(chan os.Signal, 1)
+	signal.Notify(osSignalChan, os.Interrupt, os.Kill)
+
+	sig := <-osSignalChan
+	goglog.Logger.Info(sig)
+	return nil
+}

--- a/cmd/worker_unix.go
+++ b/cmd/worker_unix.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/tsaikd/gogstash/config/goglog"
+	"golang.org/x/sync/errgroup"
 )
 
 func startWorker(args []string, attr *syscall.ProcAttr) (pid int, err error) {
@@ -67,7 +68,9 @@ func startWorkers(ctx context.Context, workers int) error {
 		pids[i] = pid
 	}
 
-	go waitWorkers(ctx, pids, args, attr)
-
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return waitWorkers(ctx, pids, args, attr)
+	})
 	return waitSignals(ctx)
 }

--- a/cmd/worker_unix.go
+++ b/cmd/worker_unix.go
@@ -27,7 +27,7 @@ func waitWorkers(ctx context.Context, pids []int, args []string, attr *syscall.P
 		// wait for any child process
 		pid, err := syscall.Wait4(-1, &ws, 0, nil)
 		if err != nil {
-			goglog.Logger.Error("wait4() error: %v", err)
+			goglog.Logger.Errorf("wait4() error: %v", err)
 			continue
 		}
 		select {

--- a/cmd/worker_windows.go
+++ b/cmd/worker_windows.go
@@ -3,20 +3,77 @@
 package cmd
 
 import (
+	"context"
 	"os"
 	"syscall"
+	"unsafe"
+
+	"github.com/tsaikd/gogstash/config/goglog"
 )
 
-func startWorker() (int, error) {
-	execSpec := &syscall.ProcAttr{
+func startWorker(args []string, attr *syscall.ProcAttr) (pid int, handle uintptr, err error) {
+	pid, handle, err = syscall.StartProcess(os.Args[0], args, attr)
+	if err != nil {
+		goglog.Logger.Errorf("start worker failed: %v", err)
+		return
+	}
+	goglog.Logger.Infof("worker started: %d", pid)
+	return
+}
+
+func waitWorkers(ctx context.Context, pids []int, handles []uintptr, args []string, attr *syscall.ProcAttr) error {
+	// syscall only has `WaitForSingleObject`, but we have to wait multiple processes,
+	// so that we find proc `WaitForMultipleObjects` from kernel32.dll.
+	// doc: https://docs.microsoft.com/en-us/windows/desktop/api/synchapi/nf-synchapi-waitformultipleobjects
+	dll := syscall.MustLoadDLL("kernel32.dll")
+	wfmo := dll.MustFindProc("WaitForMultipleObjects")
+	for {
+		r1, _, err := wfmo.Call(uintptr(len(handles)), uintptr(unsafe.Pointer(&handles[0])), 0, syscall.INFINITE)
+		ret := int(r1)
+		if ret == syscall.WAIT_FAILED && err != nil {
+			goglog.Logger.Errorf("WaitForMultipleObjects() error: %v", err)
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			// pass
+		}
+		if ret >= syscall.WAIT_OBJECT_0 && ret < syscall.WAIT_OBJECT_0+len(handles) {
+			i := ret - syscall.WAIT_OBJECT_0
+			syscall.CloseHandle(syscall.Handle(handles[i]))
+			goglog.Logger.Warnf("worker %d stopped unexpectedly", pids[i])
+			// only restart once after stopped unexpectedly
+			pid, handle, _ := startWorker(args, attr)
+			pids[i] = pid
+			handles[i] = handle
+		}
+	}
+}
+
+func startWorkers(ctx context.Context, workers int) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	attr := &syscall.ProcAttr{
 		Env:   os.Environ(),
 		Files: []uintptr{os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd()},
 	}
 	args := append(os.Args, "--follower")
-	pid, handle, err := syscall.StartProcess(os.Args[0], args, execSpec)
-	if err == nil {
-		// succeed
-		syscall.CloseHandle(syscall.Handle(handle))
+
+	pids := make([]int, workers)
+	handles := make([]uintptr, workers)
+	for i := 0; i < workers; i++ {
+		pid, handle, err := startWorker(args, attr)
+		if err != nil {
+			return err
+		}
+		pids[i] = pid
+		handles[i] = handle
 	}
-	return pid, err
+
+	go waitWorkers(ctx, pids, handles, args, attr)
+
+	return waitSignals(ctx)
 }

--- a/cmd/worker_windows.go
+++ b/cmd/worker_windows.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 
 	"github.com/tsaikd/gogstash/config/goglog"
+	"golang.org/x/sync/errgroup"
 )
 
 func startWorker(args []string, attr *syscall.ProcAttr) (pid int, handle uintptr, err error) {
@@ -73,7 +74,9 @@ func startWorkers(ctx context.Context, workers int) error {
 		handles[i] = handle
 	}
 
-	go waitWorkers(ctx, pids, handles, args, attr)
-
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return waitWorkers(ctx, pids, handles, args, attr)
+	})
 	return waitSignals(ctx)
 }


### PR DESCRIPTION
Since we create multiple worker processes, we need to monitor their state.

The main change is the main process (if we set multiple workers) will not process events any more but management of worker processes.