### PR TITLE
grok: Add ability to accept multiple patterns for filter.

### DIFF
--- a/filter/grok/filtergrok.go
+++ b/filter/grok/filtergrok.go
@@ -69,10 +69,11 @@ func (f *FilterConfig) Event(ctx context.Context, event logevent.LogEvent) logev
 		values, err := f.grk.Parse(thisMatch, message)
 		if err != nil {
 			continue
-		}
-
-		for key, value := range values {
-			event.SetValue(key, event.Format(value))
+		} else {
+			for key, value := range values {
+				event.SetValue(key, event.Format(value))
+			}
+			break
 		}
 	}
 

--- a/filter/grok/filtergrok.go
+++ b/filter/grok/filtergrok.go
@@ -19,9 +19,9 @@ const ErrorTag = "gogstash_filter_grok_error"
 type FilterConfig struct {
 	config.FilterConfig
 
-	PatternsPath string `json:"patterns_path"` // path to patterns file
-	Match        string `json:"match"`         // match pattern
-	Source       string `json:"source"`        // source message field name
+	PatternsPath string   `json:"patterns_path"` // path to patterns file
+	Match        []string `json:"match"`         // match pattern
+	Source       string   `json:"source"`        // source message field name
 
 	grk *grok.Grok
 }
@@ -35,7 +35,7 @@ func DefaultFilterConfig() FilterConfig {
 			},
 		},
 		PatternsPath: "",
-		Match:        "%{COMMONAPACHELOG}",
+		Match:        []string{"%{COMMONAPACHELOG}"},
 		Source:       "message",
 	}
 }
@@ -64,15 +64,22 @@ func InitHandler(ctx context.Context, raw *config.ConfigRaw) (config.TypeFilterC
 // Event the main filter event
 func (f *FilterConfig) Event(ctx context.Context, event logevent.LogEvent) logevent.LogEvent {
 	message := event.GetString(f.Source)
-	values, err := f.grk.Parse(f.Match, message)
+	var err error
+	for _, thisMatch := range f.Match {
+		values, err := f.grk.Parse(thisMatch, message)
+		if err != nil {
+			continue
+		}
+
+		for key, value := range values {
+			event.SetValue(key, event.Format(value))
+		}
+	}
+
 	if err != nil {
 		event.AddTag(ErrorTag)
 		goglog.Logger.Errorf("%s: %q", err, message)
 		return event
-	}
-
-	for key, value := range values {
-		event.SetValue(key, event.Format(value))
 	}
 
 	return event

--- a/filter/grok/filtergrok_test.go
+++ b/filter/grok/filtergrok_test.go
@@ -43,7 +43,7 @@ debugch: true
 filter:
   - type: grok
     source: message
-    match: "%{NGINXTEST}"
+    match: ["%{NGINXTEST}"]
     patterns_path: "patterns"
 	`)))
 	require.NoError(err)


### PR DESCRIPTION
Also breaks backwards configuration compatibility, but allows multiple patterns to be checked before an error is thrown by the grok filter.