### PR TITLE
Add input socket udp support

### DIFF
--- a/input/beats/README.md
+++ b/input/beats/README.md
@@ -8,8 +8,11 @@ input:
   # type Must be "beats"
   - type: "beats"
 
-    # (required) server port, SO_REUSEPORT applied
+    # (required) server port
     port: 5044
+
+    # (optional) SO_REUSEPORT applied or not, default: false
+    reuseport: false
 
     # (optional) server host, default: "0.0.0.0"
     host: "0.0.0.0"

--- a/input/socket/README.md
+++ b/input/socket/README.md
@@ -1,6 +1,8 @@
 socket input
 ===================
 
+Input event message should end with new line (`\n`).
+
 ## Synopsis
 
 ```
@@ -9,17 +11,18 @@ socket input
 		{
 			"type": "socket",
 
-			// Socket type. Must be one of ["tcp", "unix", "unixpacket"].
+			// Socket type. Must be one of ["tcp", "udp", "unix", "unixpacket"].
 			"socket": "tcp",
 
-			// For TCP, address must have the form `host:port`.
+			// For TCP or UDP, address must have the form `host:port`.
 			// For Unix networks, the address must be a file system path.
-			"address": "localhost:9999"
+			"address": "localhost:9999",
+
+			// (optional) SO_REUSEPORT applied or not, default: false
+			"reuseport": false
 		}
 	]
 }
 ```
 
-> Note: at the moment, this input only works with connection-oriented sockets.
->
-> Datagram-oriented sockets like UDP or UNIXGRAM socket are not supported.
+> Note: at the moment, UNIXGRAM socket are not supported.

--- a/input/socket/inputsocket_test.go
+++ b/input/socket/inputsocket_test.go
@@ -2,12 +2,14 @@ package inputsocket
 
 import (
 	"context"
+	"net"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tsaikd/gogstash/config"
 	"github.com/tsaikd/gogstash/config/goglog"
@@ -18,7 +20,7 @@ func init() {
 	config.RegistInputHandler(ModuleName, InitHandler)
 }
 
-func Test_input_socket_module(t *testing.T) {
+func Test_input_socket_module_unix(t *testing.T) {
 	require := require.New(t)
 	require.NotNil(require)
 
@@ -32,9 +34,6 @@ input:
   - type: socket
     socket: unixpacket
     address: "/tmp/gogstash-test-unixpacket.sock"
-  - type: socket
-    socket: tcp
-    address: ":9999"
 	`)))
 	require.NoError(err)
 	require.NoError(conf.Start(ctx))
@@ -44,4 +43,97 @@ input:
 	time.Sleep(time.Duration(waitsec) * time.Second)
 	os.Remove("/tmp/gogstash-test-unix.sock")
 	os.Remove("/tmp/gogstash-test-unixpacket.sock")
+}
+
+func Test_input_socket_module_tcp(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+	require := require.New(t)
+	require.NotNil(require)
+
+	ctx := context.Background()
+	conf, err := config.LoadFromYAML([]byte(strings.TrimSpace(`
+debugch: true
+input:
+  - type: socket
+    socket: tcp
+    address: "127.0.0.1:9999"
+	`)))
+	require.NoError(err)
+	require.NoError(conf.Start(ctx))
+
+	time.Sleep(500 * time.Millisecond)
+
+	conn, err := net.Dial("tcp", "127.0.0.1:9999")
+	require.NoError(err)
+	defer conn.Close()
+
+	testWriteData(t, conf, conn)
+}
+
+func Test_input_socket_module_udp(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+	require := require.New(t)
+	require.NotNil(require)
+
+	ctx := context.Background()
+	conf, err := config.LoadFromYAML([]byte(strings.TrimSpace(`
+debugch: true
+input:
+  - type: socket
+    socket: udp
+    address: "127.0.0.1:9998"
+	`)))
+	require.NoError(err)
+	require.NoError(conf.Start(ctx))
+
+	time.Sleep(500 * time.Millisecond)
+
+	conn, err := net.Dial("udp", "127.0.0.1:9998")
+	require.NoError(err)
+	defer conn.Close()
+
+	testWriteData(t, conf, conn)
+}
+
+func testWriteData(t *testing.T, conf config.Config, conn net.Conn) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+	require := require.New(t)
+	require.NotNil(require)
+
+	_, err := conn.Write([]byte("{\"foo\":\"bar\"}\n"))
+	require.NoError(err)
+
+	time.Sleep(200 * time.Millisecond)
+	if event, err := conf.TestGetOutputEvent(100 * time.Millisecond); assert.NoError(err) {
+		assert.Equal(map[string]interface{}{"foo": "bar"}, event.Extra)
+	}
+
+	// malformed data
+	_, err = conn.Write([]byte("114514\n"))
+	require.NoError(err)
+
+	time.Sleep(200 * time.Millisecond)
+	if event, err := conf.TestGetOutputEvent(100 * time.Millisecond); assert.NoError(err) {
+		assert.Equal("114514\n", event.Message)
+	}
+
+	_, err = conn.Write([]byte("{\"foo\":\"bar\"dr.who}\n"))
+	require.NoError(err)
+
+	time.Sleep(200 * time.Millisecond)
+	if event, err := conf.TestGetOutputEvent(100 * time.Millisecond); assert.NoError(err) {
+		assert.Equal("{\"foo\":\"bar\"dr.who}\n", event.Message)
+	}
+
+	// continued
+	_, err = conn.Write([]byte("{\"bar\":\"foo\"}\n"))
+	require.NoError(err)
+
+	time.Sleep(200 * time.Millisecond)
+	if event, err := conf.TestGetOutputEvent(100 * time.Millisecond); assert.NoError(err) {
+		assert.Equal(map[string]interface{}{"bar": "foo"}, event.Extra)
+	}
 }


### PR DESCRIPTION
Hi, I have added a UDP input support.

The breaking change is we have to use `\n` as the delimiter for every message sent to the socket input.
This simplified the error handling when there are some malformed data send to our server.

BTW, it can keep TCP connection alive now, otherwise, we may have tons of message data in the stream copy buffer as the result of `io.TeeReader`.