### PR TITLE
Allow overriding "message" field, like all other fields.

### DIFF
--- a/config/logevent/logevent.go
+++ b/config/logevent/logevent.go
@@ -159,6 +159,12 @@ func (t LogEvent) GetValue(field string) (interface{}, bool) {
 }
 
 func (t *LogEvent) SetValue(field string, v interface{}) bool {
+	if field == "message" {
+		if value, ok := v.(string); ok {
+			t.Message = value
+			return false
+		}
+	}
 	if t.Extra == nil {
 		t.Extra = map[string]interface{}{}
 	}

--- a/config/logevent/logevent_test.go
+++ b/config/logevent/logevent_test.go
@@ -299,3 +299,21 @@ func Benchmark_Marshal_StdJSON(b *testing.B) {
 		json.Marshal(jsonMap)
 	}
 }
+
+func TestChangeMessage(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+
+	newMessage := "changed"
+
+	event := LogEvent{
+		Message: "Test Message",
+	}
+
+	event.SetValue("message", newMessage)
+
+	assert.Equal(newMessage, event.Message)
+	assert.Equal(newMessage, event.Get("message"))
+	assert.Equal(newMessage, event.GetString("message"))
+
+}


### PR DESCRIPTION
Allow and use overridden "message" field, like any other field.
Otherwise things like grok filtering an overriding the "message" field do not work as the original message field keeps being used