### PR TITLE
Add common filter logic add/remove tag/field

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,28 @@ See [input modules](input) for more information
 
 ## Supported filters
 
+All filters support the following commmon functionality/configuration:
+
+```yaml
+filter:
+  - type: "whatever"
+
+    # list of tags to add
+    add_tag: ["addtag1", "addtag2"]
+    
+    # list of tags to remove
+    remove_tag: ["removetag1", "removetag2"]
+    
+    # list of fields (key/value) to add
+    add_field:
+      - key: "field1"
+        value: "value1"
+      - key: "field2"
+        value: "value2"
+    # list of fields to remove
+    remove_field: ["removefield1", "removefield2"]   
+```
+
 See [filter modules](filter) for more information
 
 * [add field](filter/addfield)

--- a/config/filter_test.go
+++ b/config/filter_test.go
@@ -1,0 +1,159 @@
+package config
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/tsaikd/gogstash/config/logevent"
+	"strings"
+	"testing"
+)
+
+func TestCommonAddTag(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+
+	event := logevent.LogEvent{}
+
+	assert.Equal(0, len(event.Tags))
+
+	filter := FilterConfig{
+		AddTags: []string{"add"},
+	}
+	event = filter.CommonFilter(context.TODO(), event)
+
+	assert.Equal(1, len(event.Tags))
+	assert.Equal("add", event.Tags[0])
+}
+
+func TestCommonRemoveTag(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+
+	event := logevent.LogEvent{Tags: []string{"removeme"}}
+
+	assert.Equal("removeme", event.Tags[0])
+
+	filter := FilterConfig{
+		RemoveTags: []string{"removeme"},
+	}
+	event = filter.CommonFilter(context.TODO(), event)
+
+	assert.Equal(0, len(event.Tags))
+}
+
+func TestCommonAddField(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+
+	event := logevent.LogEvent{}
+
+	assert.Equal("", event.GetString("addme"))
+
+	filter := FilterConfig{
+		AddFields: []FieldConfig{
+			{Key: "addme", Value: "value"},
+			{Key: "addme2", Value: "value2"},
+		},
+	}
+	event = filter.CommonFilter(context.TODO(), event)
+
+	assert.Equal("value", event.GetString("addme"))
+	assert.Equal("value", event.Get("addme"))
+
+	assert.Equal("value2", event.GetString("addme2"))
+	assert.Equal("value2", event.Get("addme2"))
+}
+
+func TestCommonRemoveField(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+
+	event := logevent.LogEvent{}
+	event.SetValue("removeme", "value")
+
+	assert.Equal("value", event.GetString("removeme"))
+	assert.Equal("value", event.Get("removeme"))
+
+	filter := FilterConfig{
+		RemoveFields: []string{"removeme"},
+	}
+	event = filter.CommonFilter(context.TODO(), event)
+
+	assert.Equal("", event.GetString("field"))
+	assert.Equal(nil, event.Get("field"))
+}
+
+func TestLoadYaml(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+
+	conf, err := LoadFromYAML([]byte(strings.TrimSpace(`
+filter:
+  - type: "whatever"
+
+    # list of tags to add
+    add_tag: ["addtag1", "addtag2"]
+    
+    # list of tags to remove
+    remove_tag: ["removetag1", "removetag2"]
+    
+    # list of fields (key/value) to add
+    add_field:
+      - key: "field1"
+        value: "value1"
+      - key: "field2"
+        value: "value2"
+    # list of fields to remove
+    remove_field: ["removefield1", "removefield2"]   
+	`)))
+	assert.NoError(err)
+
+	assert.Equal(0, len(conf.InputRaw))
+	assert.Equal(1, len(conf.FilterRaw))
+	assert.Equal(0, len(conf.OutputRaw))
+
+	// to have config updated
+	mapFilterHandler["whatever"] = func(ctx context.Context, raw *ConfigRaw) (TypeFilterConfig, error) {
+		conf := WhateverFilterConfig{}
+		err := ReflectConfig(raw, &conf)
+		if err != nil {
+			return nil, err
+		}
+		return &conf, nil
+	}
+	filters, err := conf.getFilters()
+	assert.NoError(err)
+	assert.Equal(1, len(filters))
+
+	tags := []string{"removetag1", "removetag2"}
+	event := logevent.LogEvent{Tags: tags}
+	event.SetValue("removefield1", "value1")
+	event.SetValue("removefield2", "value2")
+
+	assert.Equal(tags, event.Tags)
+	assert.Equal("value1", event.GetString("removefield1"))
+	assert.Equal("value2", event.GetString("removefield2"))
+	assert.Equal("value1", event.Get("removefield1"))
+	assert.Equal("value2", event.Get("removefield2"))
+
+	event = filters[0].CommonFilter(context.TODO(), event)
+
+	newTags := []string{"addtag1", "addtag2"}
+	assert.Equal(newTags, event.Tags)
+	assert.Equal("", event.GetString("removefield1"))
+	assert.Equal("", event.GetString("removefield2"))
+	assert.Equal(nil, event.Get("removefield1"))
+	assert.Equal(nil, event.Get("removefield2"))
+	assert.Equal("value1", event.GetString("field1"))
+	assert.Equal("value2", event.GetString("field2"))
+	assert.Equal("value1", event.Get("field1"))
+	assert.Equal("value2", event.Get("field2"))
+}
+
+type WhateverFilterConfig struct {
+	FilterConfig
+}
+
+func (f *WhateverFilterConfig) Event(ctx context.Context, event logevent.LogEvent) logevent.LogEvent {
+	return event
+}

--- a/config/logevent/logevent.go
+++ b/config/logevent/logevent.go
@@ -66,6 +66,20 @@ func (t *LogEvent) AddTag(tags ...string) {
 	}
 }
 
+// RemoveTag removes tags from event.Tags
+func (t *LogEvent) RemoveTag(tags ...string) {
+	for _, tag := range tags {
+		ftag := t.Format(tag)
+		var newTags []string
+		for _, existingTag := range t.Tags {
+			if existingTag != ftag {
+				newTags = append(newTags, existingTag)
+			}
+		}
+		t.Tags = newTags
+	}
+}
+
 // ParseTags parse tags into event.Tags
 func (t *LogEvent) ParseTags(tags interface{}) bool {
 	switch v := tags.(type) {

--- a/config/logevent/logevent_test.go
+++ b/config/logevent/logevent_test.go
@@ -118,6 +118,12 @@ func Test_Tags(t *testing.T) {
 	logevent.AddTag("tag1", "tag%{int}")
 	assert.Len(logevent.Tags, 6)
 	assert.Contains(logevent.Tags, "tag123")
+
+	logevent.RemoveTag("foo", "bar")
+	assert.Len(logevent.Tags, 4)
+	logevent.RemoveTag("notfoundtag")
+	assert.Len(logevent.Tags, 4)
+	assert.Equal([]string{"tag1", "tag2", "tag3", "tag123"}, logevent.Tags)
 }
 
 func Test_GetValue(t *testing.T) {


### PR DESCRIPTION
I'm suggesting this change so all filters allow adding/removing tags and filters, without needing a specific filter for this operation