### PR TITLE
Allow setting target field when parsing dates

### DIFF
--- a/filter/date/README.md
+++ b/filter/date/README.md
@@ -12,4 +12,6 @@ filter:
     source: time_local
     # (optional) using joda time format, eg. "YYYY-MM-dd HH:mm:ss,SSS", default: false
     joda: false
+    # (optional) target field. default: @timestamp
+    target: mytimestamp
 ```

--- a/filter/date/filterdate.go
+++ b/filter/date/filterdate.go
@@ -18,6 +18,9 @@ const ModuleName = "date"
 // ErrorTag tag added to event when process module failed
 const ErrorTag = "gogstash_filter_date_error"
 
+// DefaultTarget default event field to store date as
+const DefaultTarget = "@timestamp"
+
 // FilterConfig holds the configuration json fields and internal objects
 type FilterConfig struct {
 	config.FilterConfig
@@ -25,6 +28,7 @@ type FilterConfig struct {
 	Format []string `json:"format"` // date parse format
 	Source string   `json:"source"` // source message field name
 	Joda   bool     `json:"joda"`   // whether using joda time format
+	Target string   `json:"target"` // target field where date should be stored
 
 	timeParser func(layout, value string) (time.Time, error)
 }
@@ -39,6 +43,7 @@ func DefaultFilterConfig() FilterConfig {
 		},
 		Format: []string{time.RFC3339Nano},
 		Source: "message",
+		Target: DefaultTarget,
 	}
 }
 
@@ -100,8 +105,12 @@ func (f *FilterConfig) Event(ctx context.Context, event logevent.LogEvent) logev
 		goglog.Logger.Error(err)
 		return event
 	}
+	if f.Target == DefaultTarget {
+		event.Timestamp = timestamp.UTC()
+	} else {
+		event.SetValue(f.Target, timestamp.UTC())
+	}
 
-	event.Timestamp = timestamp.UTC()
 	return event
 }
 

--- a/filter/date/filterdate_test.go
+++ b/filter/date/filterdate_test.go
@@ -95,6 +95,47 @@ filter:
 	}
 }
 
+func Test_filter_date_module_UNIX_target(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+	require := require.New(t)
+	require.NotNil(require)
+
+	ctx := context.Background()
+	conf, err := config.LoadFromYAML([]byte(strings.TrimSpace(`
+debugch: true
+filter:
+  - type: date
+    format: ["UNIX"]
+    source: time_local
+    target: mytimestamp
+	`)))
+	require.NoError(err)
+	require.NoError(conf.Start(ctx))
+
+	timestamp, err := time.Parse("2006-01-02T15:04:05Z", "2019-01-23T09:57:51.471Z")
+	require.NoError(err)
+	eventIn := logevent.LogEvent{
+		Extra: map[string]interface{}{
+			"time_local": "1548237471.471",
+		},
+	}
+
+	expectedEvent := logevent.LogEvent{
+		Timestamp: eventIn.Timestamp,
+		Extra: map[string]interface{}{
+			"time_local":  "1548237471.471",
+			"mytimestamp": timestamp.UTC(),
+		},
+	}
+
+	conf.TestInputEvent(eventIn)
+
+	if event, err := conf.TestGetOutputEvent(300 * time.Millisecond); assert.NoError(err) {
+		require.Equal(expectedEvent, event)
+	}
+}
+
 func Test_filter_date_module_joda(t *testing.T) {
 	assert := assert.New(t)
 	assert.NotNil(assert)


### PR DESCRIPTION
Adding support for 'target' configuration for filterdate plugin