### PR TITLE
Added logic to check common configuration

### DIFF
--- a/config/filter.go
+++ b/config/filter.go
@@ -20,6 +20,11 @@ type TypeFilterConfig interface {
 	CommonFilter(context.Context, logevent.LogEvent) logevent.LogEvent
 }
 
+// IsConfigured returns whether common configuration has been setup
+func (f *FilterConfig) IsConfigured() bool {
+	return len(f.AddTags) != 0 || len(f.AddFields) != 0 || len(f.RemoveTags) != 0 || len(f.RemoveFields) != 0
+}
+
 func (f *FilterConfig) CommonFilter(ctx context.Context, event logevent.LogEvent) logevent.LogEvent {
 
 	event.AddTag(f.AddTags...)

--- a/config/filter_test.go
+++ b/config/filter_test.go
@@ -25,6 +25,23 @@ func TestCommonAddTag(t *testing.T) {
 	assert.Equal("add", event.Tags[0])
 }
 
+func TestCommonIsConfigured(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+
+	var filter FilterConfig
+
+	assert.False(filter.IsConfigured(), "should be not configured")
+	withAddTag := FilterConfig{AddTags: []string{"tag"}}
+	assert.True(withAddTag.IsConfigured(), "should be configured")
+	withAddFields := FilterConfig{AddFields: []FieldConfig{FieldConfig{Key: "name", Value: "value"}}}
+	assert.True(withAddFields.IsConfigured(), "should be configured")
+	withRemoveTag := FilterConfig{RemoveTags: []string{"tag"}}
+	assert.True(withRemoveTag.IsConfigured(), "should be configured")
+	withRemoveFields := FilterConfig{RemoveFields: []string{"field"}}
+	assert.True(withRemoveFields.IsConfigured(), "should be configured")
+}
+
 func TestCommonRemoveTag(t *testing.T) {
 	assert := assert.New(t)
 	assert.NotNil(assert)

--- a/filter/mutate/filtermutate.go
+++ b/filter/mutate/filtermutate.go
@@ -51,7 +51,7 @@ func InitHandler(ctx context.Context, raw *config.ConfigRaw) (config.TypeFilterC
 		return nil, err
 	}
 
-	if conf.Split[0] == "" && conf.Replace[0] == "" && conf.Merge[0] == "" && conf.Rename[0] == "" {
+	if conf.Split[0] == "" && conf.Replace[0] == "" && conf.Merge[0] == "" && conf.Rename[0] == "" && !conf.IsConfigured() {
 		return nil, ErrNotConfigured
 	}
 

--- a/filter/mutate/filtermutate_test.go
+++ b/filter/mutate/filtermutate_test.go
@@ -65,6 +65,20 @@ filter:
 		require.Equal(expectedEvent, event)
 	}
 }
+func Test_filter_mutate_module_configured(t *testing.T) {
+	require := require.New(t)
+	require.NotNil(require)
+
+	ctx := context.Background()
+	conf, err := config.LoadFromYAML([]byte(strings.TrimSpace(`
+debugch: true
+filter:
+  - type: mutate
+    add_tag: ["testing"]
+	`)))
+	require.NoError(err)
+	require.NoError(conf.Start(ctx))
+}
 
 func Test_filter_mutate_module_split(t *testing.T) {
 	assert := assert.New(t)


### PR DESCRIPTION
This change allows mutate filter to be configured only with common config parameters.
E.g.

  - type: mutate
    add_tag: ["testing"]

there is also an IsConfigured function that can be used by filters to validate