### PR TITLE
Changed log level when no match

### DIFF
--- a/filter/grok/filtergrok.go
+++ b/filter/grok/filtergrok.go
@@ -96,7 +96,7 @@ func (f *FilterConfig) Event(ctx context.Context, event logevent.LogEvent) logev
 
 	if !found {
 		event.AddTag(ErrorTag)
-		goglog.Logger.Errorf("grok: no matches for %q", message)
+		goglog.Logger.Debugf("grok: no matches for %q", message)
 	}
 
 	return event


### PR DESCRIPTION
Suggesting this change as often grok is used to set tags and make branching decisions based on that. Logging as error is just polluting the output too much