### PR TITLE
Condition filter needs to call CommonFilter on children

### DIFF
--- a/filter/cond/filtercond.go
+++ b/filter/cond/filtercond.go
@@ -149,10 +149,12 @@ func (f *FilterConfig) Event(ctx context.Context, event logevent.LogEvent) logev
 		if r, ok := ret.(bool); ok {
 			if r {
 				for _, filter := range f.filters {
+					event = filter.CommonFilter(ctx, event)
 					event = filter.Event(ctx, event)
 				}
 			} else {
 				for _, filter := range f.elseFilters {
+					event = filter.CommonFilter(ctx, event)
 					event = filter.Event(ctx, event)
 				}
 			}


### PR DESCRIPTION
This fixes an issue I introduced since the common filter logic was not invoked by condition filters.