### PR TITLE
Fields created using json filter should be parseable with the date filter

### DIFF
--- a/filter/date/filterdate_test.go
+++ b/filter/date/filterdate_test.go
@@ -2,6 +2,8 @@ package filterdate
 
 import (
 	"context"
+	"fmt"
+	filterjson "github.com/tsaikd/gogstash/filter/json"
 	"strings"
 	"testing"
 	"time"
@@ -17,6 +19,7 @@ import (
 func init() {
 	goglog.Logger.SetLevel(logrus.DebugLevel)
 	config.RegistFilterHandler(ModuleName, InitHandler)
+	config.RegistFilterHandler(filterjson.ModuleName, filterjson.InitHandler)
 }
 
 func Test_filter_date_module(t *testing.T) {
@@ -172,5 +175,109 @@ filter:
 
 	if event, err := conf.TestGetOutputEvent(300 * time.Millisecond); assert.NoError(err) {
 		require.Equal(expectedEvent, event)
+	}
+}
+
+func Test_filter_date_module_float(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+	require := require.New(t)
+	require.NotNil(require)
+
+	ctx := context.Background()
+	conf, err := config.LoadFromYAML([]byte(strings.TrimSpace(`
+debugch: true
+filter:
+  - type: json
+    source: json
+  - type: date
+    format: ["UNIX"]
+    source: time_local
+	`)))
+	require.NoError(err)
+	require.NoError(conf.Start(ctx))
+
+	conf.TestInputEvent(logevent.LogEvent{
+		Extra: map[string]interface{}{
+			"json": `{"time_local": 1558348989869}`,
+		},
+	})
+
+	// this should NOT result in gogstash_filter_date_error tag
+	if event, err := conf.TestGetOutputEvent(300 * time.Millisecond); assert.NoError(err) {
+		require.Equal(0, len(event.Tags))
+	}
+}
+
+func Test_filter_date_convert(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+
+	type inputOutput struct {
+		name  string
+		input interface{}
+		sec   int64
+		nsec  int64
+	}
+	tests := []inputOutput{
+		{
+			name:  "whole float",
+			input: float64(1558348989869),
+			sec:   int64(1558348989869),
+			nsec:  int64(0),
+		},
+		{
+			name:  "decimal float",
+			input: float64(15583.48989869),
+			sec:   int64(15583),
+			nsec:  int64(489898690),
+		},
+		{
+			name:  "whole string",
+			input: "1558348989869",
+			sec:   int64(1558348989869),
+			nsec:  int64(0),
+		},
+		{
+			name:  "fraction string",
+			input: "1548237471.471",
+			sec:   int64(1548237471),
+			nsec:  int64(471000000),
+		},
+		{
+			name:  "exp string",
+			input: "1.558349e+12",
+			sec:   int64(1558349000000),
+			nsec:  int64(0),
+		},
+		{
+			name:  "exp string 2",
+			input: "1.558348989869e+12",
+			sec:   int64(1558348989869),
+			nsec:  int64(0),
+		},
+		{
+			name:  "int",
+			input: int64(1558348989869),
+			sec:   int64(1558348989869),
+			nsec:  int64(0),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := require.New(t)
+			r.NotNil(r)
+			var sec, nsec int64
+			var err error
+			switch input := test.input.(type) {
+			case float64:
+				sec, nsec = convertFloat(input)
+			default:
+				sec, nsec, err = convert(fmt.Sprintf("%v", input))
+			}
+			r.NoError(err)
+			r.Equal(test.sec, sec)
+			r.Equal(test.nsec, nsec)
+		})
 	}
 }


### PR DESCRIPTION
jsonfilter unmarshalls a string into json. 
By default, json numbers will be unmarshalled to float64.
Date filter is not expecting numbers in exponential notation such as float64's Printf("%v")