### PR TITLE
logevent: add compile path token cache

### DIFF
--- a/config/logevent/pathvalue_test.go
+++ b/config/logevent/pathvalue_test.go
@@ -6,6 +6,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func BenchmarkCompilePath(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		compilePath("a.b.c")
+		compilePath("a.b[1].c")
+		compilePath("a.b[0][2].c")
+		compilePath("[0]")
+		compilePath("nginx.access.url")
+	}
+}
+
+func BenchmarkCompilePathWithCache(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		compilePathWithCache("a.b.c")
+		compilePathWithCache("a.b[1].c")
+		compilePathWithCache("a.b[0][2].c")
+		compilePathWithCache("[0]")
+		compilePathWithCache("nginx.access.url")
+	}
+}
+
 func TestCompilePath(t *testing.T) {
 	assert := assert.New(t)
 	assert.NotNil(assert)


### PR DESCRIPTION
This will make `logevent.Get` a slightly faster.

```
goos: windows
goarch: amd64
pkg: github.com/tsaikd/gogstash/config/logevent
BenchmarkCompilePath-12             	 1000000	      1523 ns/op	    1360 B/op	      19 allocs/op
BenchmarkCompilePathWithCache-12    	 2000000	       692 ns/op	      80 B/op	       5 allocs/op
PASS
```