### PR TITLE
Elastic legacy

### DIFF
--- a/output/elastic/README.md
+++ b/output/elastic/README.md
@@ -14,9 +14,9 @@ output:
     # index name to log
     index: "gogstash-index-test"
 
-    # (deprecated)
+    # Only for old versions of Elasticsearch. Leave empty for recent versions.
     # type name to log
-    document_type: "testtype"
+    document_type: ""
 
     # (optional) default: ""
     # id to log, used if you want to control id format

--- a/output/elastic/outputelastic.go
+++ b/output/elastic/outputelastic.go
@@ -190,6 +190,12 @@ func (t *OutputConfig) Output(ctx context.Context, event logevent.LogEvent) (err
 		RetryOnConflict(t.RetryOnConflict).
 		Id(id).
 		Doc(event)
+
+	if t.DocumentType != "" {
+		doctype := event.Format(t.DocumentType)
+		indexRequest.Type(doctype)
+	}
+
 	t.processor.Add(indexRequest)
 
 	return


### PR DESCRIPTION
This change should allow this plugin to work in new and old Elasticsearch versions. 
What do you think about it?