### PR TITLE
add TLS support for dockerlog & dockerstats input

### DIFF
--- a/input/dockerlog/README.md
+++ b/input/dockerlog/README.md
@@ -23,6 +23,15 @@ gogstash input docker
 
 			// (optional), in seconds, docker connection retry interval, default: 10
 			"connection_retry_interval": 10
+
+			// (optional), path of TLS cert, default: ""
+			"tls_cert": "/tmp/cert.pem"
+
+			// (optional), path of TLS key, default: ""
+			"tls_cert_key": "/tmp/key.pem"
+
+			// (optional), path of TLS CA cert, default: ""
+			"tls_ca_cert": "/tmp/ca.pem"
 		}
 	]
 }

--- a/input/dockerstats/README.md
+++ b/input/dockerstats/README.md
@@ -26,6 +26,15 @@ gogstash input dockerstats
 
 			// (optional), filter the output by mode, available value: "full" | "simple", "simple" mode will remove some messages to make the log smaller, default: "full"
 			"log_mode": "full"
+
+			// (optional), path of TLS cert, default: ""
+			"tls_cert": "/tmp/cert.pem"
+
+			// (optional), path of TLS key, default: ""
+			"tls_cert_key": "/tmp/key.pem"
+
+			// (optional), path of TLS CA cert, default: ""
+			"tls_ca_cert": "/tmp/ca.pem"
 		}
 	]
 }


### PR DESCRIPTION
Hi,

First thx for the work.

For my personal use, i need to use dockerlog and dockerstat input on a docker available via TCP over TLS.

In order to test this, you have to setup a docker with tlsverify option https://docs.docker.com/engine/security/https/ or just use socat to forward from a tls tcp listener to the docker unix socket : 
`socat -d -v -d TCP-L:2375,fork UNIX:/var/run/docker.sock`
