### PR TITLE
Add sensible default useragent regexes; add README

### DIFF
--- a/filter/useragent/README.md
+++ b/filter/useragent/README.md
@@ -1,0 +1,59 @@
+gogstash useragent filter module
+=============================
+
+This filter parses a useragent string in the log event message to a structured form.
+
+## Synopsis
+
+```yaml
+filter:
+  - type: useragent
+    # message field to parse
+    source: headers.user_agent
+    # target field
+    target: user_agent
+    # (optional) YAML file of user agent regexes to match. Default: regexes from uaparser
+    # You can find the latest version of this here:
+    # <https://github.com/ua-parser/uap-core/blob/master/regexes.yaml>
+    regexes: "./regex.yaml"
+    # (optional) Number of entries to cache, to avoid re-parsing the same user agents repeatedly. Default: 100000
+    cache_size: 1000
+```
+
+## Example for useragent
+
+Input string
+```json
+{
+    "headers": {
+      "user_agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36"
+    }
+}
+```
+
+Config:
+```yaml
+filter:
+  - type: useragent
+    source: headers.user_agent
+    target: user_agent
+```
+
+Produces the following output:
+```json
+{
+    "headers": {
+      "user_agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36"
+    },
+    "user_agent": {
+        "device": "Other",
+        "major": "59",
+        "minor": "0",
+        "name": "Chrome",
+        "os": "Windows",
+        "os_major": "7",
+        "os_name": "Windows",
+        "patch": "3071"
+    }
+}
+```

--- a/filter/useragent/README.md
+++ b/filter/useragent/README.md
@@ -26,7 +26,7 @@ Input string
 ```json
 {
     "headers": {
-      "user_agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36"
+        "user_agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36"
     }
 }
 ```
@@ -43,7 +43,7 @@ Produces the following output:
 ```json
 {
     "headers": {
-      "user_agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36"
+        "user_agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36"
     },
     "user_agent": {
         "device": "Other",

--- a/filter/useragent/filteruseragent.go
+++ b/filter/useragent/filteruseragent.go
@@ -15,6 +15,7 @@ const ModuleName = "useragent"
 
 // errors
 var (
+	// Deprecated: this error is never returned.
 	ErrRegexesNotConfigured = errors.New("filter useragent `regexes` not configured")
 )
 
@@ -96,12 +97,12 @@ func InitHandler(ctx context.Context, raw *config.ConfigRaw) (config.TypeFilterC
 	}
 
 	if conf.Regexes == "" {
-		return nil, ErrRegexesNotConfigured
-	}
-
-	conf.parser, err = uaparser.New(conf.Regexes)
-	if err != nil {
-		return nil, err
+		conf.parser = uaparser.NewFromSaved()
+	} else {
+		conf.parser, err = uaparser.New(conf.Regexes)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	conf.fields.Init(conf.Target)

--- a/filter/useragent/filteruseragent.go
+++ b/filter/useragent/filteruseragent.go
@@ -2,7 +2,6 @@ package filteruseragent
 
 import (
 	"context"
-	"errors"
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/tsaikd/gogstash/config"
@@ -12,12 +11,6 @@ import (
 
 // ModuleName is the name used in config file
 const ModuleName = "useragent"
-
-// errors
-var (
-	// Deprecated: this error is never returned.
-	ErrRegexesNotConfigured = errors.New("filter useragent `regexes` not configured")
-)
 
 type uaFields struct {
 	Name    string

--- a/filter/useragent/filteruseragent_test.go
+++ b/filter/useragent/filteruseragent_test.go
@@ -40,7 +40,7 @@ func init() {
 	}
 }
 
-func Test_filter_useragent_module_error(t *testing.T) {
+func Test_filter_useragent_module_default(t *testing.T) {
 	require := require.New(t)
 	require.NotNil(require)
 
@@ -51,7 +51,7 @@ filter:
   - type: useragent
 	`)))
 	require.NoError(err)
-	require.Error(conf.Start(ctx))
+	require.NoError(conf.Start(ctx))
 }
 
 func Test_filter_useragent_module_parse(t *testing.T) {


### PR DESCRIPTION
This adds a sensible default configuration to the `useragent` filter when no regex file is specified, using [`uaparser.NewFromSaved`](https://godoc.org/github.com/ua-parser/uap-go/uaparser#NewFromSaved). It also adds a README for this filter.

Closes #136.