### PR TITLE
Fix README elastic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ filter:
 
 output:
   - type: elastic
-    url: "http://elastic.server:9200"
+    url: ["http://elastic.server:9200"]
     index: "log-nginx-%{+@2006-01-02}"
     document_type: "%{type}"
 ```


### PR DESCRIPTION
`url` must be an array. If I try to use the original configuration I get:

```
Error: initialize output module failed: map[document_type:doc index:gogstash type:elastic url:http://elastic.server:9200]; json: cannot unmarshal string into Go struct field OutputConfig.url of type []string
```