### PR TITLE
Updates to Elastic

### DIFF
--- a/output/elastic/README.md
+++ b/output/elastic/README.md
@@ -34,6 +34,10 @@ output:
     # find all nodes of your cluster, https://github.com/olivere/elastic/wiki/Sniffing
     sniff: true
 
+    # (optional) default: false
+    # uses the simpleclient connection type instead of the normal client, helpful in cases you get error messages even when the client can connect
+    simple_client: true
+
     # (optional) default: 1000
     # BulkActions specifies when to flush based on the number of actions
     # currently added. Defaults to 1000 and can be set to -1 to be disabled.

--- a/output/elastic/outputelastic.go
+++ b/output/elastic/outputelastic.go
@@ -30,6 +30,7 @@ type OutputConfig struct {
 	RetryOnConflict int      `json:"retry_on_conflict"` // the number of times Elasticsearch should internally retry an update/upserted document
 	Username        string   `json:"username"`          // basic auth username to Elasticsearch
 	Password        string   `json:"password"`          // basic auth password to Elasticsearch
+	SimpleClient    bool     `json:"simple_client"`     // if set uses simpleclient instead of newclient, disables some functionality
 
 	Sniff bool `json:"sniff"` // find all nodes of your cluster, https://github.com/olivere/elastic/wiki/Sniffing
 
@@ -138,7 +139,12 @@ func InitHandler(ctx context.Context, raw *config.ConfigRaw) (config.TypeOutputC
 		options = append(options, elastic.SetHttpClient(client))
 	}
 
-	if conf.client, err = elastic.NewClient(options...); err != nil {
+	if conf.SimpleClient {
+		conf.client, err = elastic.NewSimpleClient(options...)
+	} else {
+		conf.client, err = elastic.NewClient(options...)
+	}
+	if err != nil {
 		return nil, ErrorCreateClientFailed1.New(err, conf.URL)
 	}
 

--- a/output/elasticv5/README.md
+++ b/output/elasticv5/README.md
@@ -21,9 +21,21 @@ output:
     # id to log, used if you want to control id format
     document_id: "%{fieldstring}"
 
+    # (optional) default: ""
+    # username to use in basic auth
+    username: ""
+
+    # (optional) default: ""
+    # password to use in basic auth
+    password: ""
+
     # (optional) default: false
     # find all nodes of your cluster, https://github.com/olivere/elastic/wiki/Sniffing
     sniff: true
+
+    # (optional) default: false
+    # uses the simpleclient connection type instead of the normal client, helpful in cases you get error messages even when the client can connect
+    simple_client: true
 
     # (optional) default: 1000
     # BulkActions specifies when to flush based on the number of actions


### PR DESCRIPTION
This is an update to #143 where I also added the username/auth to elasticv5 and also added support for NewSimpleClient as mentioned in #144. NewSimpleClient solves a few connectivity issues with some installations. Read more about it [here](https://github.com/olivere/elastic/wiki/Connection-Problems#how-to-figure-out-connection-problems).