### PR TITLE
geoip2: documentation and private IP

### DIFF
--- a/filter/geoip2/README.md
+++ b/filter/geoip2/README.md
@@ -16,6 +16,14 @@ filter:
     # (required) ip address field to parse
     ip_field: remote_addr
     # (optional) parsed geoip info should saved to field, default: geoip
+    skip_private: true
+    # (optional) does not try to process private IP networks as they will fail, default: false
+    private_net:
+      - 10.0.0.0/8
+      - 192.168.0.0/16
+    # (optional) lets you specify your own definition for private IP addresses, both IPv4 and IPv6, default is private IP addresses
+    cache_size: 100000
+    # (optional) size of cache entries on IP addresses, so lookups don't go through the database, default is 100000
     key: geoip
     # (optional) parsed geoip info into flat format, default: false
     # `city_name`, `continent_code`, `country_code`, `country_name`,

--- a/filter/geoip2/filtergeoip2.go
+++ b/filter/geoip2/filtergeoip2.go
@@ -26,6 +26,7 @@ type FilterConfig struct {
 	Key         string `json:"key"`          // geoip destination field name, default: geoip
 	QuietFail   bool   `json:"quiet"`        // fail quietly
 	SkipPrivate bool   `json:"skip_private"` // skip private IP addresses
+	PrivateNet []string `json:"private_net"` // list of own defined private IP addresses
 	FlatFormat  bool   `json:"flat_format"`  // flat format
 	CacheSize   int    `json:"cache_size"`   // cache size
 
@@ -74,6 +75,12 @@ func InitHandler(ctx context.Context, raw *config.ConfigRaw) (config.TypeFilterC
 		"127.0.0.0/8",
 		"172.16.0.0/12",
 		"192.168.0.0/16",
+		"fc00::/7",
+		"fe80::/10",
+		"169.254.0.0/16",
+	}
+	if len(conf.PrivateNet) > 0 {
+		cidrs = conf.PrivateNet
 	}
 	for _, cidr := range cidrs {
 		_, privateCIDR, _ := net.ParseCIDR(cidr)


### PR DESCRIPTION
I looked through the geoip2 module and suggest the following changes:

- Update of documentation to include some of the parameters that were not previously documented.
- Added some more default prefixes into the list of private networks, among some IPv6 networks.
- Added a new field private_net that allows the user to configure their own list of private IP addresses.