### PR TITLE
Added ip2location filter

### DIFF
--- a/filter/ip2location/README.md
+++ b/filter/ip2location/README.md
@@ -1,0 +1,53 @@
+# gogstash ip2location filter module
+
+You need to download ip2location database manually and setup file path in config.
+
+* [Paying customers](https://www.ip2location.com/file-download)
+* [Free databases](https://lite.ip2location.com)
+
+The database will be reloaded when changed.
+
+## Synopsis
+
+```yaml
+filter:
+  - type: ip2location
+    # (required) database file path
+    db_path: "IP-COUNTRY.BIN"
+
+    # (required) ip address field to parse
+    ip_field: remote_addr
+
+    # (optional) parsed ip2location info should be saved to field, default: ip2location
+    key: ip2location
+
+    # (optional) does not try to process private IP networks as they will fail, default: false
+    skip_private: true
+
+    # (optional) lets you specify your own definition for private IP addresses, both IPv4 and IPv6, default is private IP addresses
+    private_net:
+      - 10.0.0.0/8
+      - 192.168.0.0/16
+
+    # (optional) size of cache entries on IP addresses, so lookups don't go through the database, default is 100000
+    cache_size: 100000
+
+```
+
+Based on an input like this:
+```json
+{
+  "ip": "1.1.1.1"
+}
+```
+
+You should get an output like this with a country database:
+```json
+{
+  "ip": "1.1.1.1",
+  "ip2location": {
+    "country_code": "US",
+    "country_name": "United States of America"
+  }
+}
+```

--- a/filter/ip2location/filterip2location.go
+++ b/filter/ip2location/filterip2location.go
@@ -1,0 +1,235 @@
+package filterip2location
+
+import (
+	"context"
+	"github.com/fsnotify/fsnotify"
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/ip2location/ip2location-go/v9"
+	"github.com/tsaikd/gogstash/config"
+	"github.com/tsaikd/gogstash/config/goglog"
+	"github.com/tsaikd/gogstash/config/logevent"
+	"net"
+	"sync"
+	"time"
+)
+
+// ModuleName is the name used in config file
+const ModuleName = "ip2location"
+
+// ErrorTag tag added to event when process ip2location failed
+const ErrorTag = "gogstash_filter_ip2location_error"
+
+// FilterConfig holds the configuration json fields and internal objects
+type FilterConfig struct {
+	config.FilterConfig
+
+	DBPath      string   `json:"db_path" yaml:"db_path"`           // ip2location .BIN file
+	IPField     string   `json:"ip_field" yaml:"ip_field"`         // IP field to get geolocation for
+	Key         string   `json:"key"`                              // destination field name
+	QuietFail   bool     `json:"quiet" yaml:"quiet"`               // fail quietly
+	SkipPrivate bool     `json:"skip_private" yaml:"skip_private"` // skip private IP addresses
+	PrivateNet  []string `json:"private_net" yaml:"private_net"`   // list of own defined private IP addresses
+	CacheSize   int      `json:"cache_size" yaml:"cache_size"`     // cache size
+
+	dbMtx sync.RWMutex    // lock for db
+	db    *ip2location.DB // database
+
+	cache        *lru.Cache
+	privateCIDRs []*net.IPNet
+
+	watcher *fsnotify.Watcher
+	ctx     context.Context
+}
+
+// DefaultCIDR is the default list of CIDRs to filter out
+var DefaultCIDR = []string{
+	"10.0.0.0/8",
+	"100.64.0.0/10",
+	"127.0.0.0/8",
+	"172.16.0.0/12",
+	"192.168.0.0/16",
+	"fc00::/7",
+	"fe80::/10",
+	"169.254.0.0/16",
+}
+
+// DefaultFilterConfig returns an FilterConfig struct with default values
+func DefaultFilterConfig() FilterConfig {
+	return FilterConfig{
+		FilterConfig: config.FilterConfig{
+			CommonConfig: config.CommonConfig{
+				Type: ModuleName,
+			},
+		},
+		Key:         ModuleName,
+		QuietFail:   false, // backwards compatible
+		SkipPrivate: false,
+		CacheSize:   100000,
+	}
+}
+
+// reloadFile reloads the file from disk invalidates the cache
+func (fc *FilterConfig) reloadFile() {
+	newDb, err := ip2location.OpenDB(fc.DBPath)
+	if err != nil {
+		goglog.Logger.Errorf("ip2location failed to update %s: %s", fc.DBPath, err.Error())
+		return
+	}
+	oldDb := fc.db
+	fc.dbMtx.Lock()
+	fc.db = newDb
+	fc.dbMtx.Unlock()
+	oldDb.Close()
+	fc.cache.Purge()
+	goglog.Logger.Infof("ip2location reloaded file %s", fc.DBPath)
+}
+
+// initFsnotifyEventHandler is called by InitHandler and sets up a background thread that watches for changes
+func (fc *FilterConfig) initFsnotifyEventHandler() {
+	const pauseDelay = 5 * time.Second // used to let all changes be done before reloading the file
+	go func() {
+		timer := time.NewTimer(0)
+		defer timer.Stop()
+		firstTime := true
+		for {
+			select {
+			case <-timer.C:
+				if firstTime {
+					firstTime = false
+				} else {
+					fc.reloadFile()
+				}
+			case <-fc.watcher.Events:
+				timer.Reset(pauseDelay)
+			case err := <-fc.watcher.Errors:
+				goglog.Logger.Errorf("ip2location: %s", err.Error())
+			case <-fc.ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+// InitHandler initialize the filter plugin
+func InitHandler(ctx context.Context, raw *config.ConfigRaw) (config.TypeFilterConfig, error) {
+	conf := DefaultFilterConfig()
+	err := config.ReflectConfig(raw, &conf)
+	if err != nil {
+		return nil, err
+	}
+
+	conf.ctx = ctx
+
+	// open database
+	conf.db, err = ip2location.OpenDB(conf.DBPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// init cache
+	conf.cache, err = lru.New(conf.CacheSize)
+	if err != nil {
+		return nil, err
+	}
+
+	goglog.Logger.Info("ip2location fsnotify initialized for", conf.DBPath)
+
+	// init fsnotify
+	conf.watcher, err = fsnotify.NewWatcher()
+	if err != nil {
+		goglog.Logger.Errorf("ip2location failed to init watcher, %s", err.Error())
+	}
+	err = conf.watcher.Add(conf.DBPath)
+	if err != nil {
+		goglog.Logger.Errorf("ip2location failed to add file: %s", err.Error())
+	}
+	conf.initFsnotifyEventHandler()
+
+	var cidrs []string
+	if len(conf.PrivateNet) > 0 {
+		cidrs = conf.PrivateNet
+	} else {
+		cidrs = DefaultCIDR
+	}
+
+	for _, cidr := range cidrs {
+		_, privateCIDR, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, err
+		}
+		conf.privateCIDRs = append(conf.privateCIDRs, privateCIDR)
+	}
+
+	return &conf, nil
+}
+
+// not_supported is copied from ip2location and is the field entry for each field that is not supported by the current database
+const not_supported string = "This parameter is unavailable for selected data file. Please upgrade the data file."
+
+// Event the main filter event
+func (f *FilterConfig) Event(ctx context.Context, event logevent.LogEvent) (logevent.LogEvent, bool) {
+	ipstr := event.GetString(f.IPField)
+	if ipstr == "" {
+		// Passthru if empty
+		return event, false
+	}
+	ip := net.ParseIP(ipstr)
+	if ip == nil {
+		return event, false
+	}
+	if f.SkipPrivate && f.privateIP(ip) {
+		// Passthru
+		return event, false
+	}
+	var record *ip2location.IP2Locationrecord
+	if c, ok := f.cache.Get(ipstr); ok {
+		record = c.(*ip2location.IP2Locationrecord)
+	} else {
+		f.dbMtx.RLock()
+		r2, err := f.db.Get_all(ipstr)
+		f.dbMtx.RUnlock()
+		record = &r2
+		if err != nil {
+			if f.QuietFail {
+				goglog.Logger.Error(err)
+			}
+			event.AddTag(ErrorTag)
+			return event, false
+		}
+		f.cache.Add(ipstr, record)
+	}
+	if record == nil {
+		event.AddTag(ErrorTag)
+		return event, false
+	}
+
+	m := map[string]interface{}{
+		"country_code": record.Country_short,
+		"country_name": record.Country_long,
+	}
+	if record.City != not_supported {
+		m["city_name"] = record.City
+		m["region_name"] = record.Region
+	}
+	if record.Isp != not_supported {
+		m["ISP"] = record.Isp
+	}
+	if record.Latitude != 0 || record.Longitude != 0 {
+		m["location"] = []float32{record.Longitude, record.Latitude}
+		m["latitude"] = record.Latitude
+		m["longitude"] = record.Longitude
+	}
+
+	event.SetValue(f.Key, m)
+	return event, true
+}
+
+// privateIP returns true if ip is in list of private IP addresses
+func (f *FilterConfig) privateIP(ip net.IP) bool {
+	for _, cidr := range f.privateCIDRs {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/go.mod
+++ b/go.mod
@@ -12,13 +12,14 @@ require (
 	github.com/containerd/containerd v1.5.4 // indirect
 	github.com/drhodes/golorem v0.0.0-20160418191928-ecccc744c2d9
 	github.com/elastic/go-lumber v0.1.0
-	github.com/fsnotify/fsnotify v1.4.9
+	github.com/fsnotify/fsnotify v1.5.1
 	github.com/fsouza/go-dockerclient v1.7.3
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/mock v1.4.3
 	github.com/gomodule/redigo v2.0.0+incompatible // indirect
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/icza/dyno v0.0.0-20200205103839-49cb13720835
+	github.com/ip2location/ip2location-go/v9 v9.1.0 // indirect
 	github.com/json-iterator/go v1.1.10
 	github.com/lib/pq v1.3.0 // indirect
 	github.com/libp2p/go-reuseport v0.0.1
@@ -29,6 +30,7 @@ require (
 	github.com/msaf1980/statsd v0.0.0-20210625220633-8d91df059a07
 	github.com/nats-io/nats-server/v2 v2.2.0
 	github.com/nats-io/nats.go v1.10.1-0.20210228004050-ed743748acac
+	github.com/nsqio/go-nsq v1.0.8 // indirect
 	github.com/olivere/elastic/v7 v7.0.14
 	github.com/opencontainers/runc v1.0.1 // indirect
 	github.com/oschwald/geoip2-golang v1.4.0
@@ -50,7 +52,7 @@ require (
 	github.com/yuin/gopher-lua v0.0.0-20190206043414-8bfc7677f583 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	golang.org/x/sys v0.0.0-20210923061019-b8560ed6a9b7 // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 	gopkg.in/ini.v1 v1.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -290,6 +290,8 @@ github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
+github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fsouza/go-dockerclient v1.7.3 h1:i6iMcktl688vsKUEExA6gU1UjPgIvmGtJeQ0mbuFqZo=
 github.com/fsouza/go-dockerclient v1.7.3/go.mod h1:8xfZB8o9SptLNJ13VoV5pMiRbZGWkU/Omu5VOu/KC9Y=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
@@ -437,6 +439,10 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/ip2location/ip2location-go v8.3.0+incompatible h1:QwUE+FlSbo6bjOWZpv2Grb57vJhWYFNPyBj2KCvfWaM=
+github.com/ip2location/ip2location-go v8.3.0+incompatible/go.mod h1:3JUY1TBjTx1GdA7oRT7Zeqfc0bg3lMMuU5lXmzdpuME=
+github.com/ip2location/ip2location-go/v9 v9.1.0 h1:DVlKxIcjA7CsA0cgzbidwe6eKzpbkS313LsH9ceutxI=
+github.com/ip2location/ip2location-go/v9 v9.1.0/go.mod h1:s5SV6YZL10TpfPpXw//7fEJC65G/yH7Oh+Tjq9JcQEQ=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jcmturner/gofork v1.0.0 h1:J7uCkflzTEhUZ64xqKnkDxq3kzc96ajM1Gli5ktUem8=
 github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
@@ -581,6 +587,8 @@ github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/nlopes/slack v0.6.0/go.mod h1:JzQ9m3PMAqcpeCam7UaHSuBuupz7CmpjehYMayT6YOk=
+github.com/nsqio/go-nsq v1.0.8 h1:3L2F8tNLlwXXlp2slDUrUWSBn2O3nMh8R1/KEDFTHPk=
+github.com/nsqio/go-nsq v1.0.8/go.mod h1:vKq36oyeVXgsS5Q8YEO7WghqidAVXQlcFxzQbQTuDEY=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -982,6 +990,8 @@ golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210923061019-b8560ed6a9b7 h1:c20P3CcPbopVp2f7099WLOqSNKURf30Z0uq66HpijZY=
+golang.org/x/sys v0.0.0-20210923061019-b8560ed6a9b7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201113234701-d7a72108b828/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/modloader/modloader.go
+++ b/modloader/modloader.go
@@ -10,6 +10,7 @@ import (
 	filtergonx "github.com/tsaikd/gogstash/filter/gonx"
 	filtergrok "github.com/tsaikd/gogstash/filter/grok"
 	filterhash "github.com/tsaikd/gogstash/filter/hash"
+	filterip2location "github.com/tsaikd/gogstash/filter/ip2location"
 	filterjson "github.com/tsaikd/gogstash/filter/json"
 	filterkv "github.com/tsaikd/gogstash/filter/kv"
 	filterlookuptable "github.com/tsaikd/gogstash/filter/lookuptable"
@@ -69,6 +70,7 @@ func init() {
 	config.RegistFilterHandler(filtergeoip2.ModuleName, filtergeoip2.InitHandler)
 	config.RegistFilterHandler(filtergonx.ModuleName, filtergonx.InitHandler)
 	config.RegistFilterHandler(filtergrok.ModuleName, filtergrok.InitHandler)
+	config.RegistFilterHandler(filterip2location.ModuleName, filterip2location.InitHandler)
 	config.RegistFilterHandler(filterjson.ModuleName, filterjson.InitHandler)
 	config.RegistFilterHandler(filtermutate.ModuleName, filtermutate.InitHandler)
 	config.RegistFilterHandler(filterratelimit.ModuleName, filterratelimit.InitHandler)


### PR DESCRIPTION
ip2location is another geo database, like geoip2 - but another provider. This filter is built using their own official library and is based on the code from the geoip2 filter.

I also added some code for FileWatcher - but should this be placed somewhere else? My intention is to reuse this code other places (geoip2, ip2proxy) when the database is updated.

To be able to test this filter yourself you need to create a free account on https://lite.ip2location.com