### PR TITLE
Changed quiet behaviour in geoip filters

### DIFF
--- a/filter/geoip2/README.md
+++ b/filter/geoip2/README.md
@@ -37,4 +37,7 @@ filter:
     # `city_name`, `continent_code`, `country_code`, `country_name`,
     # `ip`, `latitude`, `longitude`, `postal_code`, `region_code`, `region_name` and `timezone`.
     flat_format: false
+
+    # (optional) if true does not log lookup failures from the database, default is false
+    quiet: true
 ```

--- a/filter/geoip2/filtergeoip2.go
+++ b/filter/geoip2/filtergeoip2.go
@@ -24,14 +24,14 @@ const ErrorTag = "gogstash_filter_geoip2_error"
 type FilterConfig struct {
 	config.FilterConfig
 
-	DBPath      string   `json:"db_path"`      // geoip2 db file path, default: GeoLite2-City.mmdb
-	IPField     string   `json:"ip_field"`     // IP field to get geoip info
-	Key         string   `json:"key"`          // geoip destination field name, default: geoip
-	QuietFail   bool     `json:"quiet"`        // fail quietly
-	SkipPrivate bool     `json:"skip_private"` // skip private IP addresses
-	PrivateNet  []string `json:"private_net"`  // list of own defined private IP addresses
-	FlatFormat  bool     `json:"flat_format"`  // flat format
-	CacheSize   int      `json:"cache_size"`   // cache size
+	DBPath      string   `json:"db_path" yaml:"db_path"`           // geoip2 db file path, default: GeoLite2-City.mmdb
+	IPField     string   `json:"ip_field" yaml:"ip_field"`         // IP field to get geoip info
+	Key         string   `json:"key" yaml:"key"`                   // geoip destination field name, default: geoip
+	QuietFail   bool     `json:"quiet" yaml:"quiet"`               // fail quietly
+	SkipPrivate bool     `json:"skip_private" yaml:"skip_private"` // skip private IP addresses
+	PrivateNet  []string `json:"private_net" yaml:"private_net"`   // list of own defined private IP addresses
+	FlatFormat  bool     `json:"flat_format" yaml:"flat_format"`   // flat format
+	CacheSize   int      `json:"cache_size" yaml:"cache_size"`     // cache size
 
 	db      *geoip2.Reader
 	dbMtx   sync.RWMutex
@@ -136,7 +136,7 @@ func (f *FilterConfig) Event(ctx context.Context, event logevent.LogEvent) (loge
 		record, err = f.db.City(ip)
 		f.dbMtx.RUnlock()
 		if err != nil {
-			if f.QuietFail {
+			if !f.QuietFail {
 				goglog.Logger.Error(err)
 			}
 			event.AddTag(ErrorTag)

--- a/filter/ip2location/README.md
+++ b/filter/ip2location/README.md
@@ -32,6 +32,8 @@ filter:
     # (optional) size of cache entries on IP addresses, so lookups don't go through the database, default is 100000
     cache_size: 100000
 
+    # (optional) if true does not log lookup failures from the database, default is false
+    quiet: true
 ```
 
 Based on an input like this:

--- a/filter/ip2location/filterip2location.go
+++ b/filter/ip2location/filterip2location.go
@@ -190,7 +190,7 @@ func (f *FilterConfig) Event(ctx context.Context, event logevent.LogEvent) (loge
 		f.dbMtx.RUnlock()
 		record = &r2
 		if err != nil {
-			if f.QuietFail {
+			if !f.QuietFail {
 				goglog.Logger.Error(err)
 			}
 			event.AddTag(ErrorTag)

--- a/filter/ip2proxy/README.md
+++ b/filter/ip2proxy/README.md
@@ -33,6 +33,8 @@ filter:
     # (optional) size of cache entries on IP addresses, so lookups don't go through the database, default is 100000
     cache_size: 100000
 
+    # (optional) if true does not log lookup failures from the database, default is false
+    quiet: true
 ```
 
 Based on an input like this:

--- a/filter/ip2proxy/filterip2proxy.go
+++ b/filter/ip2proxy/filterip2proxy.go
@@ -136,7 +136,7 @@ func (f *FilterConfig) Event(ctx context.Context, event logevent.LogEvent) (loge
 		record, err = f.db.GetAll(ipstr)
 		f.dbMtx.RUnlock()
 		if err != nil {
-			if f.QuietFail {
+			if !f.QuietFail {
 				goglog.Logger.Error(err)
 			}
 			event.AddTag(ErrorTag)


### PR DESCRIPTION
I have now changed how quiet works for the filters geoip2, ip2location and ip2proxy. The new behaviour is that if a DB lookup fails the error will be logged unless quiet is set to true, then the error is silently discarded.