### PR TITLE
added disabled as an option for inputs, filters and outputs

### DIFF
--- a/config/commonconfig.go
+++ b/config/commonconfig.go
@@ -7,7 +7,8 @@ type TypeCommonConfig interface {
 
 // CommonConfig is basic config struct
 type CommonConfig struct {
-	Type string `json:"type"`
+	Type     string `json:"type"`
+	Disabled bool   `json:"disabled" yaml:"disabled"` // if set the input/output/filter will be disabled
 }
 
 // GetType return module type of config

--- a/config/input.go
+++ b/config/input.go
@@ -40,16 +40,24 @@ func RegistInputHandler(name string, handler InputHandler) {
 func (t *Config) getInputs() (inputs []TypeInputConfig, err error) {
 	var input TypeInputConfig
 	for _, raw := range t.InputRaw {
-		handler, ok := mapInputHandler[raw["type"].(string)]
-		if !ok {
-			return inputs, ErrorUnknownInputType1.New(nil, raw["type"])
+		// check if input is disabled
+		var disabled bool
+		if result, ok := raw["disabled"].(bool); ok {
+			disabled = result
 		}
+		// load input if not disabled
+		if !disabled {
+			handler, ok := mapInputHandler[raw["type"].(string)]
+			if !ok {
+				return inputs, ErrorUnknownInputType1.New(nil, raw["type"])
+			}
 
-		if input, err = handler(t.ctx, &raw); err != nil {
-			return inputs, ErrorInitInputFailed1.New(err, raw)
+			if input, err = handler(t.ctx, &raw); err != nil {
+				return inputs, ErrorInitInputFailed1.New(err, raw)
+			}
+
+			inputs = append(inputs, input)
 		}
-
-		inputs = append(inputs, input)
 	}
 	return
 }


### PR DESCRIPTION
I propose to add a new parameter on all input, output and filters. This parameter - disabled - if set to true will block the configuration block to be parsed and used.

I think this parameter is useful in many ways during testing, debugging av development. For me I can easily remove a block of configuration without removing it from the configuration file.

```yaml
input:
 - type: "my-new-input"
   disabled: true
```

With a configuration like the one above I can disable the input with ease instead of changing the entire configuration file.