### PR TITLE
added Encode() to codecs

### DIFF
--- a/codec/json/codecjson.go
+++ b/codec/json/codecjson.go
@@ -94,9 +94,14 @@ func (c *Codec) DecodeEvent(data []byte, event *logevent.LogEvent) (err error) {
 	return
 }
 
-// Encode function not implement (TODO)
-func (c *Codec) Encode(ctx context.Context, event logevent.LogEvent, dataChan chan<- []byte) (ok bool, err error) {
-	return false, config.ErrorNotImplement1.New(nil)
+// Encode encodes the event to a JSON encoded message
+func (c *Codec) Encode(_ context.Context, event logevent.LogEvent, dataChan chan<- []byte) (ok bool, err error) {
+	output, err := event.MarshalJSON()
+	if err != nil {
+		return false, err
+	}
+	dataChan <- output
+	return true, nil
 }
 
 func (c *Codec) populateEventExtras(event *logevent.LogEvent) {

--- a/config/codec.go
+++ b/config/codec.go
@@ -180,7 +180,14 @@ func (c *DefaultCodec) DecodeEvent(data []byte, event *logevent.LogEvent) error 
 	return nil
 }
 
-// Encode function not implemented (TODO)
+// Encode sends the message field, ignoring any extra fields
 func (c *DefaultCodec) Encode(ctx context.Context, event logevent.LogEvent, dataChan chan<- []byte) (ok bool, err error) {
-	return false, ErrorNotImplement1.New(nil)
+	// return if there is no message field
+	if len(event.Message) == 0 {
+		return false, nil
+	}
+	// send message
+	dataChan <- []byte(event.Message)
+
+	return true, nil
 }

--- a/output/stdout/README.md
+++ b/output/stdout/README.md
@@ -3,11 +3,12 @@ gogstash output stdout
 
 ## Synopsis
 
-```
+```json
 {
 	"output": [
 		{
-			"type": "stdout"
+			"type": "stdout",
+      "codec": "json"
 		}
 	]
 }
@@ -18,4 +19,6 @@ gogstash output stdout
 Used for debug
 
 * type
-	* Must be **"stdout"**
+  * Must be **"stdout"**
+* codec
+  * Can be any supported codec that generates non-binary output. "default" prints the input message as it is and "json" prints the input as JSON.


### PR DESCRIPTION
I looked at the codec and added some code to Encode() for both JSON and the default to be able to produce output using encode. I also rewrote stdout to be able to prove that it works.

At this point I added Codec directly to stdout instead of config.Outputconfig for two reasons. One is that #170 is proposing a change on the same file, but also because I am just testing the codec Encode() as this point.

The reason for doing this is that some outputs can benefit from a codec. NSQ in #168 could use this to control the output format depending on what your needs are.