### PR TITLE
Added codec support to outputnsq

### DIFF
--- a/config/output.go
+++ b/config/output.go
@@ -24,6 +24,7 @@ type TypeOutputConfig interface {
 // OutputConfig is basic output config struct
 type OutputConfig struct {
 	CommonConfig
+	Codec string // name of codec to load
 }
 
 // OutputHandler is a handler to regist output module

--- a/output/nsq/README.md
+++ b/output/nsq/README.md
@@ -16,4 +16,7 @@ output:
 
     # (optional) The number of inflight messages to handle, default is 150
     max_inflight: 75
+
+    # (optional) Configures what codec to produce the output on, default is "default"
+    codec: "json"
 ```

--- a/output/stdout/outputstdout.go
+++ b/output/stdout/outputstdout.go
@@ -15,7 +15,6 @@ const ModuleName = "stdout"
 type OutputConfig struct {
 	config.OutputConfig
 
-	Codec string                 // name of codec to load
 	msg   chan []byte            // channel to push message from codec to
 	codec config.TypeCodecConfig // the codec we will use
 	ctx   context.Context


### PR DESCRIPTION
With this update I have changed outputnsq to use a codec to produce the output instead of hardcoded JSON.

I have also moved Codec (for documentation purposes) from stdout to config.OutputConfig.