### PR TITLE
Codec issues

### DIFF
--- a/config/output.go
+++ b/config/output.go
@@ -24,7 +24,7 @@ type TypeOutputConfig interface {
 // OutputConfig is basic output config struct
 type OutputConfig struct {
 	CommonConfig
-	Codec string // name of codec to load
+	Codec TypeCodecConfig `json:"-"` // name of codec to load
 }
 
 // OutputHandler is a handler to regist output module


### PR DESCRIPTION
I have addressed two issues here.

1. OutputConfig Codec of type string that can be parsed by the JSON unmarshalling function does not work when you try to pass configuration into a codec. I changed Codec to be of same type as for InputConfig.
2. A panic situation as a result of GetCodecDefault() not checking if a codec was initialised. I think most modules use GetCodecOrDefault() which does this properly, so this was a specific issue with the socket input that defaults to the JSON codec.
3. A panic situation in getCodec() with mapCodecHandler as we assume that type casting raw["type"].(string) always succeeds.

I found these issues when leaving codec type undefined or set to an unknown codec.

Example config:
```json
{
 "input": [
   "type": "socket",
   "codec": {
      "type": "default",
      "some_param": "test"
   }
 ]
}
```