### PR TITLE
Refactored queue

### DIFF
--- a/config/queue/README.md
+++ b/config/queue/README.md
@@ -1,0 +1,58 @@
+# queue
+
+This queue implements queueing and control logic to handle backpressure in case an output cannot deliver events for any reason.
+The control logic that an input can listen to is implemented in [control.go](../control.go).
+For this guide I assume you already have some understanding in how gogstash works internally.
+
+The queue is designed to make it easier for developers to write outputs that does backpressurehandling and queueing, without rewriting all code every time.
+
+Later down in this guide you will see how to rewrite existing outputs to support backpressure.
+
+## Components of the queue
+
+There are [two interfaces](queue.go) that you need to understand.
+
+* QueueReceiver - defines all gogstash common types and OutputEvent(). The only method you need to implement in your code for the queue to work is OutputEvent().
+* Queue - defines all gogstash common types, Queue() and Resume(). Queue() is used to signal that you have an issue and put the event on the queue. Resume() is called every time the output delivers an event and makes sure that the inputs are resumed.
+
+## simpleQueue
+
+This implementation of a queue retries any events at a specified interval. If there are more than one event in the queue and the queue is paused, then one event will be sent out. The output module has to queue it back if it fails delivery.
+If the queue is in normal state then all events in the queue will be sent immediately.
+
+## Customizing existing outputs
+
+The output [http](../../output/http) is implementing using the steps in this guide and can be used as a reference on how to implement queueing.
+
+For this guide it is assumed that the existing output only handles events synchronously; ie the current Output() method does not return before the event either was delivered or failed delivery.
+
+First you need to edit the modules OutputConfig and add the queue:
+```go
+type OutputConfig struct {
+	// existing defs
+  queue queue.Queue
+}
+```
+
+During InitHandler() you will need to create a new queue object and pass it back.
+```go
+func InitHandler(
+	ctx context.Context,
+	raw config.ConfigRaw,
+	control config.Control,
+) (config.TypeOutputConfig, error) {
+	conf := DefaultOutputConfig()
+	// all your custom init code
+  conf.queue = queue.NewSimpleQueue(ctx, control, &conf, 1, 30) // last values are queue size and retry interval in seconds
+  return conf.queue, nil
+}
+```
+
+The next thing you need to do is to find the handlers existing Output() handler. Change its name to OutputEvent(), this way you satisfy the implementation of queue.QueueReceiver.
+
+At last, rewrite the OutputEvent() handler. You need to make two changes:
+1. If the event was delivered successfully, exit the handler with ```return t.queue.Resume(ctx)```.
+2. If you failed delivery and this is something that you want to retry at a later time then call ```t.queue.Queue(ctx, event)``` and handle any errors. Exit with an error appropriate for why the output failed.
+
+The developer should drop any events that have fatal errors - where the receiver is actively failing the event because of errors that likely will not go away.
+Examples on such errors are page not found (404) and access denied (401).

--- a/config/queue/queue.go
+++ b/config/queue/queue.go
@@ -1,0 +1,35 @@
+package queue
+
+import (
+	"context"
+	"github.com/tsaikd/KDGoLib/errutil"
+	"github.com/tsaikd/gogstash/config"
+	"github.com/tsaikd/gogstash/config/logevent"
+)
+
+// QueueReceiver defines an interface for using a queue when incoming events has to pause.
+// This should be the output object, implementing OutputEvent and TypeCommonConfig.
+type QueueReceiver interface {
+	config.TypeCommonConfig
+
+	// OutputEvent is the event that is called from the queue when an event is to be processed. This
+	// event typically replaces your existing Output() and is called when an event is ready to be sent out on the output.
+	OutputEvent(ctx context.Context, event logevent.LogEvent) (err error)
+}
+
+// Queue allows for queueing of data into the queue
+type Queue interface {
+	config.TypeCommonConfig                                    // has to be here to be a supported TypeOutputConfig.
+	Output(ctx context.Context, event logevent.LogEvent) error // has to be here to be a supported TypeOutputConfig.
+	Queue(ctx context.Context, event logevent.LogEvent) error  // allows the output to queue an event, also pausing the input if needed. Thread safe.
+	Resume(ctx context.Context) error                          // informs that the output is working again - can be called multiple times and is thread safe.
+}
+
+const (
+	StatusDelivering = iota // if we are in running mode - delivering messages
+	StatusPaused            // if we have paused the inputs
+)
+
+var (
+	ErrContextCancelled = errutil.NewFactory("context cancelled")
+)

--- a/config/queue/simplequeue.go
+++ b/config/queue/simplequeue.go
@@ -1,0 +1,156 @@
+package queue
+
+import (
+	"container/list"
+	"context"
+	"github.com/tsaikd/gogstash/config"
+	"github.com/tsaikd/gogstash/config/goglog"
+	"github.com/tsaikd/gogstash/config/logevent"
+	"sync/atomic"
+	"time"
+)
+
+// simpleQueue is an implementation of QueueReceiver with an easy retry-logic
+type simpleQueue struct {
+	RetryInterval uint `json:"retry_interval" yaml:"retry_interval"` // seconds before a new retry in case on error
+	MaxQueueSize  int  `json:"max_queue_size" yaml:"max_queue_size"` // max size of queue before deleting events (-1=no limit, 0=disable)
+
+	ctx        context.Context
+	output     QueueReceiver // the output
+	control    config.Control
+	isInPause  uint32                 // set to either StatusDelivering or StatusPaused
+	queue      chan logevent.LogEvent // channel to send events to the internal queue
+	retryqueue list.List              // list of queued messages; the list is not multithreading safe, and must only be accessed from backgroundtask()
+}
+
+// Resume informs that the output is working again - can be called multiple times and is thread safe.
+// Should be called after each successfully delivery by the output.
+func (t *simpleQueue) Resume(ctx context.Context) error {
+	if atomic.CompareAndSwapUint32(&t.isInPause, StatusPaused, StatusDelivering) {
+		goglog.Logger.Debug("queue: requesting resume")
+		return t.control.RequestResume(ctx)
+	}
+	return nil
+}
+
+// Queue queues an event into the queue, blocking if necessary until cancelled. Queue is used from the output to put something into the queue.
+// A call to add an event onto the queue will also pause the input.
+func (t *simpleQueue) Queue(ctx context.Context, event logevent.LogEvent) error {
+	if atomic.CompareAndSwapUint32(&t.isInPause, StatusDelivering, StatusPaused) {
+		goglog.Logger.Debug("queue is requesting pause")
+		err := t.control.RequestPause(ctx)
+		if err != nil {
+			goglog.Logger.Error("queue: ", err.Error())
+		}
+	}
+	select {
+	case t.queue <- event:
+		return nil
+	case <-ctx.Done():
+		return ErrContextCancelled.New(nil)
+	}
+}
+
+// NewSimpleQueue returns a new queue using a simple retry/queuing mechanism. receiver is your Output object. queueSize is the number of events that will be queued before dropping events from the queue; with a value of -1 the sky is the limit. retryInterval is the time in seconds between each retry.
+func NewSimpleQueue(ctx context.Context, control config.Control, receiver QueueReceiver, queueSize int, retryInterval uint) Queue {
+	var chanSize int
+	if queueSize < 1 {
+		chanSize = 1
+	} else {
+		chanSize = queueSize
+	}
+	s := &simpleQueue{
+		RetryInterval: retryInterval,
+		MaxQueueSize:  queueSize,
+		ctx:           ctx,
+		output:        receiver,
+		control:       control,
+		isInPause:     StatusDelivering,
+		queue:         make(chan logevent.LogEvent, chanSize),
+		retryqueue:    list.List{},
+	}
+	go s.backgroundtask()
+	return s
+}
+
+// GetType satisfies TypeCommonConfig
+func (t *simpleQueue) GetType() string {
+	return t.output.GetType()
+}
+
+// Output satisfies TypeOutputConfig and is handling incoming events
+func (t *simpleQueue) Output(ctx context.Context, event logevent.LogEvent) (err error) {
+	// see if output has requested pause and if so just queue the event instead of trying
+	if atomic.LoadUint32(&t.isInPause) == StatusPaused {
+		select {
+		case t.queue <- event:
+			return nil
+		case <-ctx.Done():
+			return ErrContextCancelled.New(nil)
+		case <-t.ctx.Done():
+			return ErrContextCancelled.New(nil)
+		}
+	}
+	// If we are not in pause mode then call the sender method
+	return t.output.OutputEvent(ctx, event)
+}
+
+// backgroundtask is running in the background and adds new events to the queue, tries to send them out on the RetryInterval.
+func (t *simpleQueue) backgroundtask() {
+	goglog.Logger.Debug("backgroundtask started")
+	dur := time.Duration(t.RetryInterval) * time.Second
+	ticker := time.NewTicker(dur)
+	defer ticker.Stop()
+	for {
+		select {
+		case event := <-t.queue:
+			if (t.retryqueue.Len() < t.MaxQueueSize) || t.MaxQueueSize == -1 {
+				t.retryqueue.PushBack(event)
+			}
+		case <-t.ctx.Done():
+			goglog.Logger.Debug("queue closing")
+			return
+		case <-ticker.C:
+			// We have reached a RetryInterval. If there are any events in the queue, lets send one back.
+			// If we are still in pause mode we will send one, if we are in normal mode we will send all back.
+			if e := t.retryqueue.Front(); e != nil {
+				if atomic.LoadUint32(&t.isInPause) == StatusPaused {
+					event := e.Value.(logevent.LogEvent)
+					t.retryqueue.Remove(e)
+					go func() {
+						ctx, cancel := context.WithTimeout(context.Background(), dur)
+						err := t.output.OutputEvent(ctx, event)
+						if err != nil {
+							goglog.Logger.Error("queue: sendone ", err.Error())
+						}
+						cancel()
+					}()
+				} else {
+					// we are not in pause mode and will queue all the events in the queue for sending.
+					// First we need to empty the queue and get all events to send.
+					myList := []*logevent.LogEvent{}
+					for {
+						e := t.retryqueue.Front()
+						if e == nil {
+							break
+						}
+						event := e.Value.(logevent.LogEvent)
+						myList = append(myList, &event)
+						t.retryqueue.Remove(e)
+					}
+					// Now we have to send them all out
+					go func() {
+						for x := range myList {
+							ctx, cancel := context.WithTimeout(context.Background(), dur)
+							err := t.Output(ctx, *myList[x])
+							if err != nil {
+								goglog.Logger.Error("queue: sendall", err.Error())
+							}
+							cancel()
+						}
+					}()
+				}
+			}
+		}
+	}
+}

--- a/config/queue/simplequeue_test.go
+++ b/config/queue/simplequeue_test.go
@@ -1,0 +1,133 @@
+package queue
+
+import (
+	"context"
+	"github.com/tsaikd/gogstash/config/logevent"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// controlCounter is used to count control messages, so we can check it is as expected
+type controlCounter struct {
+	lock sync.Mutex // lock for all data
+
+	numPause  uint32 //  number of pauses
+	numResume uint32 // number of resumes
+
+	pause  chan struct{}
+	resume chan struct{}
+}
+
+func newControlCounter() *controlCounter {
+	return &controlCounter{resume: make(chan struct{}), pause: make(chan struct{})}
+}
+
+func (c *controlCounter) RequestPause(ctx context.Context) error {
+	c.lock.Lock()
+	c.numPause++
+	old := c.resume
+	c.resume = make(chan struct{})
+	c.lock.Unlock()
+	close(old)
+	return nil
+}
+
+func (c *controlCounter) RequestResume(ctx context.Context) error {
+	c.lock.Lock()
+	c.numResume++
+	old := c.pause
+	c.pause = make(chan struct{})
+	c.lock.Unlock()
+	close(old)
+	return nil
+}
+
+func (c *controlCounter) PauseSignal() <-chan struct{} {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.pause
+}
+
+func (c *controlCounter) ResumeSignal() <-chan struct{} {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.resume
+}
+
+type sampleOutput struct {
+	numReceived uint32        // increments for each message received
+	numSent     uint32        // increments for each message delivered
+	queue       Queue         // our queue
+	target      uint32        // number of messages that we want to receive
+	doneCh      chan struct{} // closed when target # of messages has been received
+	FailMsgId   []uint32      // received message # to fail on
+}
+
+func (s *sampleOutput) GetType() string {
+	return "sampleOutput"
+}
+
+const numMessages = 140
+
+func (s *sampleOutput) OutputEvent(ctx context.Context, event logevent.LogEvent) (err error) {
+	id := atomic.AddUint32(&s.numReceived, 1)
+	var failed bool
+	for x := range s.FailMsgId {
+		if s.FailMsgId[x] == id {
+			failed = true
+			break
+		}
+	}
+	if failed {
+		_ = s.queue.Queue(ctx, event)
+	} else {
+		_ = s.queue.Resume(ctx)
+		if atomic.AddUint32(&s.numSent, 1) >= s.target {
+			close(s.doneCh)
+		}
+	}
+	return nil
+}
+
+// check that we receive
+func TestNewSimpleQueue1(t *testing.T) {
+	control := newControlCounter()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	o := &sampleOutput{doneCh: make(chan struct{}), target: numMessages, FailMsgId: []uint32{1, 2, 100}}
+	q := NewSimpleQueue(ctx, control, o, numMessages, 1)
+	o.queue = q
+	// send four messages
+	go func() {
+		event := logevent.LogEvent{}
+		for x := 0; x < numMessages; x++ {
+			event.Message = strconv.Itoa(x)
+			_ = q.Output(ctx, event)
+		}
+	}()
+	// wait and see
+	select {
+	case <-ctx.Done():
+		t.Errorf("test timed out after %v events", atomic.LoadUint32(&o.numReceived))
+		return
+	case <-o.doneCh:
+		break
+	}
+	// check if we got the expected result
+	numFails := uint32(len(o.FailMsgId))
+	if o.numSent != numMessages {
+		t.Errorf("Received %v messages, expected %v messages", o.numSent, numMessages)
+	}
+	if o.numReceived != uint32(numMessages+numFails) {
+		t.Errorf("Sent %v messages, received %v messages", numMessages, o.numReceived)
+	}
+	if control.numPause == 0 {
+		t.Error("control got no pauses, expected at least 1")
+	}
+	if control.numResume == 0 {
+		t.Error("control got no resumes, expected at least 1")
+	}
+}


### PR DESCRIPTION
After looking into outputhttp I found lots of code that I can reuse. Instead of writing all code over again I propose to move much of the backpressure/queueing logic out to a separate class that can be reused several places. I hope this can make it easier to implement backpressure in more outputs and still have readable code.