### PR TITLE
Changed os exit signals

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/tsaikd/KDGoLib/errutil"
@@ -128,7 +129,7 @@ func initConfig(config *Config) {
 
 // Start config in goroutines
 func (t *Config) Start(ctx context.Context) (err error) {
-	ctx = contextWithOSSignal(ctx, goglog.Logger, os.Interrupt, os.Kill)
+	ctx = contextWithOSSignal(ctx, goglog.Logger, os.Interrupt, syscall.SIGTERM)
 	t.eg, t.ctx = errgroup.WithContext(ctx)
 
 	if err = t.startInputs(); err != nil {


### PR DESCRIPTION
I have been looking into signal handling in worker.go and config.go. With workers we exit on SIGINT and SIGTERM whereas without workers we exit on SIGINT and SIGKILL.

This change adds SIGTERM into config.go and I also removed SIGKILL as we don't forcefully can't close gogstash if any input/filter/output hangs during cleanup.