### PR TITLE
Implement gelf output

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ See [output modules](output) for more information
 * [cond](output/cond)
 * [elastic](output/elastic)
 * [email](output/email)
+* [GELF](output/gelf)
 * [NSQ](output/nsq)
 * [prometheus](output/prometheus)
 * [redis](output/redis)

--- a/modloader/modloader.go
+++ b/modloader/modloader.go
@@ -40,6 +40,7 @@ import (
 	outputelasticv5 "github.com/tsaikd/gogstash/output/elasticv5"
 	outputemail "github.com/tsaikd/gogstash/output/email"
 	outputfile "github.com/tsaikd/gogstash/output/file"
+	outputgelf "github.com/tsaikd/gogstash/output/gelf"
 	outputhttp "github.com/tsaikd/gogstash/output/http"
 	outputkafka "github.com/tsaikd/gogstash/output/kafka"
 	outputnsq "github.com/tsaikd/gogstash/output/nsq"
@@ -90,6 +91,7 @@ func init() {
 	config.RegistOutputHandler(outputelastic.ModuleName, outputelastic.InitHandler)
 	config.RegistOutputHandler(outputelasticv5.ModuleName, outputelasticv5.InitHandler)
 	config.RegistOutputHandler(outputemail.ModuleName, outputemail.InitHandler)
+	config.RegistOutputHandler(outputgelf.ModuleName, outputgelf.InitHandler)
 	config.RegistOutputHandler(outputhttp.ModuleName, outputhttp.InitHandler)
 	config.RegistOutputHandler(outputnsq.ModuleName, outputnsq.InitHandler)
 	config.RegistOutputHandler(outputprometheus.ModuleName, outputprometheus.InitHandler)

--- a/output/gelf/README.md
+++ b/output/gelf/README.md
@@ -1,0 +1,43 @@
+# gogstash output GELF
+
+[GELF](https://docs.graylog.org/docs/gelf) (Graylog Extended Log Format) is a Graylog log format
+
+## Synopsis
+
+```yaml
+output:
+  - type: "gelf"
+
+    # List of Graylog Gelf Input. Format should be host:port
+    hosts:
+      - localhost:2022
+
+    # (optional)
+    # The maximum size of a chunk.
+    # Default: 1420
+    chunk_size: 1420
+
+    # (optional)
+    # The Level of compression.
+    # Between 0 (None) to 9 (Best Compression).
+    # Default: 1
+    compression_level: 1420
+
+    # (optional)
+    # Type of compression.
+    #  - Gzip: 0
+    #  - Zlib: 1
+    #  - None: 2
+    # Default: 0 (Gzip)
+    compression_type: 0
+
+    # (optional)
+    # How often to retry to send messages in case it was not delivered successfully
+    # Default: 30 seconds
+    retry_interval: 30
+
+    # (optional)
+    # The maximum size of messages that can be queued (in case of delivery issues) before messages are dropped.
+    # Default is one message, use -1 to not limit the queue.
+    max_queue_size: 1
+```

--- a/output/gelf/gelf_writer.go
+++ b/output/gelf/gelf_writer.go
@@ -1,0 +1,462 @@
+// Copyright 2012 SocialCode. All rights reserved.
+// Use of this source code is governed by the MIT
+// license that can be found in the LICENSE file.
+
+package outputgelf
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"compress/zlib"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// regex used later
+var forbiddenExtraKeys = [7]string{
+	"_version",
+	"_host",
+	"_short_message",
+	"_full_message",
+	"_timestamp",
+	"_level",
+}
+
+type GELFConfig struct {
+	Host             string
+	ChunkSize        int          // Default Value: 1420
+	CompressionLevel int          // Default: 1
+	CompressionType  CompressType // Default: Gzip
+}
+
+type GELFWriter interface {
+	WriteCustomMessage(m *Message) error
+	WriteMessage(sm *SimpleMessage) error
+}
+
+// UDPWriter implements io.Writer and is used to send both discrete
+// messages to a graylog2 server, or data from a stream-oriented
+// interface (like the functions in log).
+type UDPWriter struct {
+	config *GELFConfig
+
+	conn net.Conn
+	mu   sync.Mutex
+
+	zw                 writerCloserResetter
+	zwCompressionLevel int
+	zwCompressionType  CompressType
+}
+
+// What compression type the writer should use when sending messages
+// to the graylog2 server
+type CompressType int
+
+const (
+	CompressGzip CompressType = iota
+	CompressZlib
+	NoCompress
+)
+
+// Message represents the contents of the GELF message.  It is gzipped
+// before sending. https://docs.graylog.org/docs/gelf
+type Message struct {
+	Extra     map[string]interface{} `json:"-"`
+	Full      string                 `json:"full_message"`
+	Host      string                 `json:"host"`
+	Level     int32                  `json:"level"`
+	Short     string                 `json:"short_message"`
+	Timestamp int64                  `json:"timestamp"`
+	Version   string                 `json:"version"`
+}
+
+type SimpleMessage struct {
+	Extra     map[string]interface{}
+	Host      string
+	Level     int32
+	Message   string
+	Timestamp time.Time
+}
+
+type innerMessage Message //against circular (Un)MarshalJSON
+
+// Used to control GELF chunking.  Should be less than (MTU - len(UDP
+// header)).
+//
+// TODO: generate dynamically using Path MTU Discovery?
+const (
+	DefaultChunkSize = 1420
+	chunkedHeaderLen = 12
+)
+
+var (
+	magicChunked = []byte{0x1e, 0x0f}
+	hostname     string
+)
+
+// numChunks returns the number of GELF chunks necessary to transmit
+// the given compressed buffer.
+func numChunks(b []byte, chunkSize int) int {
+	lenB := len(b)
+	if lenB <= chunkSize {
+		return 1
+	}
+	return len(b)/(chunkSize-chunkedHeaderLen) + 1
+}
+
+// NewWriter returns a new GELFWriter. This writer can be used to send the
+// output of the standard Go log functions to a central GELF server by
+// passing it to log.SetOutput()
+func NewWriter(config GELFConfig) (GELFWriter, error) {
+
+	// handle config
+	if config.Host == "" {
+		return nil, fmt.Errorf("missing host")
+	}
+
+	if config.ChunkSize == 0 {
+		config.ChunkSize = DefaultChunkSize
+	}
+
+	if config.CompressionLevel == 0 {
+		config.CompressionLevel = flate.BestSpeed
+	}
+
+	var err error
+	if hostname, err = os.Hostname(); err != nil {
+		panic(err)
+	}
+
+	// handle http / udp writing method
+	if strings.HasPrefix(config.Host, "http") {
+		return newHTTPWriter(&config)
+	}
+
+	return newUDPWriter(&config)
+}
+
+func newHTTPWriter(config *GELFConfig) (GELFWriter, error) {
+	httpClient := &http.Client{
+		Transport: &http.Transport{},
+		Timeout:   10 * time.Second,
+	}
+
+	return HTTPWriter{
+		config:     config,
+		httpClient: httpClient,
+	}, nil
+}
+
+func newUDPWriter(config *GELFConfig) (GELFWriter, error) {
+	var err error
+
+	w := &UDPWriter{
+		config: config,
+	}
+
+	if w.conn, err = net.Dial("udp", config.Host); err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
+func constructMessage(sm *SimpleMessage) *Message {
+
+	message := Message{
+		Extra:     sm.Extra,
+		Level:     6, // Default: Info
+		Timestamp: int64(time.Now().UnixNano() / int64(time.Millisecond) / 1000),
+		Version:   "1.1",
+	}
+
+	message.Host = hostname
+
+	// Hostname
+	if sm.Host != "" {
+		message.Host = sm.Host
+	}
+
+	if sm.Level != 0 {
+		message.Level = sm.Level
+	}
+
+	if !sm.Timestamp.IsZero() {
+		message.Timestamp = int64(sm.Timestamp.UnixNano() / int64(time.Millisecond) / 1000)
+	}
+
+	if sm.Message != "" {
+		message.Short = sm.Message
+
+		if lines := strings.Split(sm.Message, "\n"); len(lines) > 0 {
+			message.Short = lines[0]
+			message.Full = sm.Message
+		}
+	}
+
+	return &message
+}
+
+func prepareExtra(e map[string]interface{}) (map[string]interface{}, error) {
+
+	cleanExtra := make(map[string]interface{})
+
+	for k, v := range e {
+
+		newKey := k
+
+		if !strings.HasPrefix(newKey, "_") {
+			newKey = "_" + newKey
+		}
+
+		for _, forbiddenKey := range forbiddenExtraKeys {
+			if newKey == forbiddenKey {
+				return nil, fmt.Errorf("key %s is not allowed", k)
+			}
+		}
+
+		cleanExtra[newKey] = v
+	}
+
+	return cleanExtra, nil
+}
+
+/**
+* UDP IMPLEMENTATION
+**/
+
+// writes the gzip compressed byte array to the connection as a series
+// of GELF chunked messages.  The header format is documented at
+// https://github.com/Graylog2/graylog2-docs/wiki/GELF as:
+//
+//     2-byte magic (0x1e 0x0f), 8 byte id, 1 byte sequence id, 1 byte
+//     total, chunk-data
+func (w *UDPWriter) writeChunked(zBytes []byte) (err error) {
+	b := make([]byte, 0, w.config.ChunkSize)
+	buf := bytes.NewBuffer(b)
+	nChunksI := numChunks(zBytes, w.config.ChunkSize)
+	if nChunksI > 255 {
+		return fmt.Errorf("msg too large, would need %d chunks", nChunksI)
+	}
+	nChunks := uint8(nChunksI)
+	// use urandom to get a unique message id
+	msgId := make([]byte, 8)
+	n, err := io.ReadFull(rand.Reader, msgId)
+	if err != nil || n != 8 {
+		return fmt.Errorf("rand.Reader: %d/%s", n, err)
+	}
+
+	bytesLeft := len(zBytes)
+	for i := uint8(0); i < nChunks; i++ {
+		buf.Reset()
+		// manually write header.  Don't care about
+		// host/network byte order, because the spec only
+		// deals in individual bytes.
+		buf.Write(magicChunked) //magic
+		buf.Write(msgId)
+		buf.WriteByte(i)
+		buf.WriteByte(nChunks)
+		// slice out our chunk from zBytes
+		chunkLen := (w.config.ChunkSize - chunkedHeaderLen)
+		if chunkLen > bytesLeft {
+			chunkLen = bytesLeft
+		}
+		off := int(i) * (w.config.ChunkSize - chunkedHeaderLen)
+		chunk := zBytes[off : off+chunkLen]
+		buf.Write(chunk)
+
+		// write this chunk, and make sure the write was good
+		n, err := w.conn.Write(buf.Bytes())
+		if err != nil {
+			return fmt.Errorf("Write (chunk %d/%d): %s", i,
+				nChunks, err)
+		}
+		if n != len(buf.Bytes()) {
+			return fmt.Errorf("Write len: (chunk %d/%d) (%d/%d)",
+				i, nChunks, n, len(buf.Bytes()))
+		}
+
+		bytesLeft -= chunkLen
+	}
+
+	if bytesLeft != 0 {
+		return fmt.Errorf("error: %d bytes left after sending", bytesLeft)
+	}
+	return nil
+}
+
+type bufferedWriter struct {
+	buffer io.Writer
+}
+
+func (bw bufferedWriter) Write(p []byte) (n int, err error) {
+	return bw.buffer.Write(p)
+}
+
+func (bw bufferedWriter) Close() error {
+	return nil
+}
+
+func (bw *bufferedWriter) Reset(w io.Writer) {
+	bw.buffer = w
+}
+
+type writerCloserResetter interface {
+	io.WriteCloser
+	Reset(w io.Writer)
+}
+
+// WriteCustomMessage sends the specified message to the GELF server
+// specified in the call to NewWriter(). It assumes all the fields are
+// filled out appropriately. In general, clients will want to use
+// Write, rather than WriteMessage.
+func (w *UDPWriter) WriteCustomMessage(m *Message) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	mBytes, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+
+	var zBuf bytes.Buffer
+
+	// . If compression settings have changed, a new writer is required.
+	if w.zwCompressionType != w.config.CompressionType || w.zwCompressionLevel != w.config.CompressionLevel {
+		w.zw = nil
+	}
+
+	switch w.config.CompressionType {
+	case CompressGzip:
+		if w.zw == nil {
+			w.zw, err = gzip.NewWriterLevel(&zBuf, w.config.CompressionLevel)
+		}
+	case CompressZlib:
+		if w.zw == nil {
+			w.zw, err = zlib.NewWriterLevel(&zBuf, w.config.CompressionLevel)
+		}
+	case NoCompress:
+		w.zw = &bufferedWriter{}
+	default:
+		panic(fmt.Sprintf("unknown compression type %d",
+			w.config.CompressionType))
+	}
+
+	if err != nil {
+		return err
+	}
+
+	w.zw.Reset(&zBuf)
+
+	if _, err = w.zw.Write(mBytes); err != nil {
+		return err
+	}
+	w.zw.Close()
+
+	zBytes := zBuf.Bytes()
+	if numChunks(zBytes, w.config.ChunkSize) > 1 {
+		return w.writeChunked(zBytes)
+	}
+
+	n, err := w.conn.Write(zBytes)
+	if err != nil {
+		return err
+	}
+	if n != len(zBytes) {
+		return fmt.Errorf("bad write (%d/%d)", n, len(zBytes))
+	}
+
+	return nil
+}
+
+// WriteMessage allow to send messsage to gelf Server
+// It only request basic fields and will handle conversion & co
+func (w *UDPWriter) WriteMessage(sm *SimpleMessage) error {
+
+	cleanExtra, err := prepareExtra(sm.Extra)
+	if err != nil {
+		return err
+	}
+
+	sm.Extra = cleanExtra
+
+	return w.WriteCustomMessage(constructMessage(sm))
+}
+
+func (m *Message) MarshalJSON() ([]byte, error) {
+	var err error
+	var b, eb []byte
+
+	extra := m.Extra
+	b, err = json.Marshal((*innerMessage)(m))
+	m.Extra = extra
+	if err != nil {
+		return nil, err
+	}
+
+	if len(extra) == 0 {
+		return b, nil
+	}
+
+	if eb, err = json.Marshal(extra); err != nil {
+		return nil, err
+	}
+
+	// merge serialized message + serialized extra map
+	b[len(b)-1] = ','
+	return append(b, eb[1:]...), nil
+}
+
+/**
+* HTTP IMPLEMENTATION
+**/
+
+// HTTPWriter implements the GELFWriter interface, and cannot be used
+// as an io.Writer
+type HTTPWriter struct {
+	config     *GELFConfig
+	httpClient *http.Client
+}
+
+func (h HTTPWriter) WriteCustomMessage(m *Message) error {
+
+	mBytes, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+
+	resp, err := h.httpClient.Post(h.config.Host, "application/json", bytes.NewBuffer(mBytes))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 204 {
+		return fmt.Errorf("got code %s, expected 204", resp.Status)
+	}
+
+	return nil
+}
+
+// WriteMessage allow to send messsage to gelf Server
+// It only request basic fields and will handle conversion & co
+func (h HTTPWriter) WriteMessage(sm *SimpleMessage) error {
+
+	cleanExtra, err := prepareExtra(sm.Extra)
+	if err != nil {
+		return err
+	}
+
+	sm.Extra = cleanExtra
+
+	return h.WriteCustomMessage(constructMessage(sm))
+}

--- a/output/gelf/outputgelf.go
+++ b/output/gelf/outputgelf.go
@@ -1,0 +1,141 @@
+package outputgelf
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/tsaikd/KDGoLib/errutil"
+	"github.com/tsaikd/gogstash/config"
+	"github.com/tsaikd/gogstash/config/goglog"
+	"github.com/tsaikd/gogstash/config/logevent"
+	"github.com/tsaikd/gogstash/config/queue"
+)
+
+// ModuleName is the name used in config file
+const ModuleName = "gelf"
+
+// errors
+var (
+	ErrNoValidHosts          = errutil.NewFactory("no valid Hosts found")
+	ErrInvalidHost           = errutil.NewFactory("Some host are invalid. Should respect the format: hostname:port")
+	ErrorCreateClientFailed1 = errutil.NewFactory("create gelf client failed: %q")
+)
+
+// OutputConfig holds the configuration json fields and internal objects
+type OutputConfig struct {
+	config.OutputConfig
+	ChunkSize        int      `json:"chunk_size" yaml:"chunk_size"`
+	CompressionLevel int      `json:"compression_level" yaml:"compression_level"`
+	CompressionType  int      `json:"compression_type" yaml:"compression_type"`
+	Hosts            []string `json:"hosts" yaml:"hosts"` // List of Gelf Host servers, format: ip:port
+
+	RetryInterval uint `json:"retry_interval" yaml:"retry_interval"` // seconds before a new retry in case on error
+	MaxQueueSize  int  `json:"max_queue_size" yaml:"max_queue_size"` // max size of queue before deleting events (-1=no limit, 0=disable)
+
+	gelfWriters []GELFWriter
+	queue       queue.Queue // our queue
+}
+
+// DefaultOutputConfig returns an OutputConfig struct with default values
+func DefaultOutputConfig() OutputConfig {
+	return OutputConfig{
+		OutputConfig: config.OutputConfig{
+			CommonConfig: config.CommonConfig{
+				Type: ModuleName,
+			},
+		},
+		RetryInterval: 30,
+	}
+}
+
+// InitHandler initialize the output plugin
+func InitHandler(
+	ctx context.Context,
+	raw config.ConfigRaw,
+	control config.Control,
+) (config.TypeOutputConfig, error) {
+	conf := DefaultOutputConfig()
+	if err := config.ReflectConfig(raw, &conf); err != nil {
+		return nil, err
+	}
+
+	if len(conf.Hosts) <= 0 {
+		return nil, ErrNoValidHosts
+	}
+
+	// host validation regex
+	r := regexp.MustCompile(`[^\:]+:[0-9]{1,5}`)
+
+	for _, host := range conf.Hosts {
+		if !r.MatchString(host) {
+			return nil, ErrInvalidHost
+		}
+
+		gelfWriter, err := NewWriter(GELFConfig{
+			Host:             host,
+			ChunkSize:        conf.ChunkSize,
+			CompressionLevel: conf.CompressionLevel,
+			CompressionType:  CompressType(conf.CompressionType),
+		})
+		if err != nil {
+			return nil, ErrorCreateClientFailed1.New(err, host)
+		}
+
+		conf.gelfWriters = append(conf.gelfWriters, gelfWriter)
+	}
+
+	// create the queue
+	conf.queue = queue.NewSimpleQueue(ctx, control, &conf, nil, conf.MaxQueueSize, conf.RetryInterval)
+
+	return conf.queue, nil
+}
+
+// OutputEvent handle message from the queue
+func (t *OutputConfig) OutputEvent(ctx context.Context, event logevent.LogEvent) (err error) {
+	var host string
+	var level int32
+	for k, v := range event.Extra {
+
+		lk := strings.ToLower(k)
+
+		if lk == "host" || lk == "hostname" {
+			if h, ok := v.(string); ok {
+				host = h
+			}
+			delete(event.Extra, k)
+		}
+
+		if lk == "level" {
+			if l, ok := v.(int32); ok {
+				level = l
+			}
+			delete(event.Extra, k)
+		}
+	}
+
+	if len(event.Tags) > 0 {
+		event.Extra["tags"] = strings.Join(event.Tags, ", ")
+	}
+
+	for _, w := range t.gelfWriters {
+		err := w.WriteMessage(
+			&SimpleMessage{
+				Extra:     event.Extra,
+				Host:      host,
+				Level:     level,
+				Message:   event.Message,
+				Timestamp: event.Timestamp,
+			},
+		)
+		if err != nil {
+			goglog.Logger.Errorf("outputgelf: %s", err.Error())
+			err = t.queue.Queue(ctx, event)
+			if err != nil {
+				goglog.Logger.Errorf("outputgelf: %s", err.Error())
+			}
+		}
+	}
+
+	return t.queue.Resume(ctx)
+}


### PR DESCRIPTION
That implementation allow direct output to Graylog infrastructure.

Multiple implementation of gelf_writer can be found over github.
Mostly the one part of that PR is a classical version with a few adaptation to allow configuration of compression / chunkSize, ...