### PR TITLE
Added discard filter

### DIFF
--- a/config/logevent/logevent.go
+++ b/config/logevent/logevent.go
@@ -16,6 +16,7 @@ type LogEvent struct {
 	Message   string                 `json:"message"`
 	Tags      []string               `json:"tags,omitempty"`
 	Extra     map[string]interface{} `json:"-"`
+	FilterPos int                    `json:"-"` // indicates what position in the filer chain to insert this event, or set to
 }
 
 type Config struct {
@@ -25,6 +26,9 @@ type Config struct {
 	jsonMarshal       func(v interface{}) ([]byte, error)
 	jsonMarshalIndent func(v interface{}, prefix, indent string) ([]byte, error)
 }
+
+// DiscardEvent is the value for LogEvent.FilterPos when the filter chain should discard the event and stop further processing.
+const DiscardEvent = -1
 
 // TagsField is the event tags field name
 const TagsField = "tags"

--- a/filter/discard/README.md
+++ b/filter/discard/README.md
@@ -1,0 +1,28 @@
+# gogstash discard filter module
+
+This module allows you to define some conditions that will discard an event. This means that there will be no further processing of this event.
+The syntax for the conditions are described in the [cond](../cond) filter.
+
+You need to configure:
+
+1. If the event should be discarded in case we have backpressure issues (the outputs cannot send the data out). The default is not to discard events, you need to enable it.
+2. Your conditions. The event is discarded if *any* of the conditions evaluates to true.
+3. If you want to negate the behaviour of the conditions; then the event will be discarded unless *any* of the conditions evaluates to true.
+
+## Synopsis
+
+```yaml
+filter:
+  - type: discard
+
+    # (required unless you want to discard in case of backpressure)
+    conditions:
+      - "1==2"
+      - "2==3"
+
+    # (optional) if events should be discarded when we have a backpressure issue, default: false
+    discard_if_backpressure: true
+
+    # (optional) if we should negate the outcome of the conditions, default: false
+    negate_conditions: true
+```

--- a/filter/discard/filterdiscard.go
+++ b/filter/discard/filterdiscard.go
@@ -1,0 +1,127 @@
+package discard
+
+import (
+	"context"
+	"errors"
+	"github.com/Knetic/govaluate"
+	"github.com/tsaikd/gogstash/config"
+	"github.com/tsaikd/gogstash/config/goglog"
+	"github.com/tsaikd/gogstash/config/logevent"
+	filtercond "github.com/tsaikd/gogstash/filter/cond"
+	"sync/atomic"
+)
+
+const (
+	ModuleName = "discard" // the name used in config file
+	ErrorTag   = "discard_error"
+)
+
+// FilterConfig holds the configuration json fields and internal objects
+type FilterConfig struct {
+	config.FilterConfig
+	// filters data
+	control     config.Control
+	ctx         context.Context
+	expressions []*govaluate.EvaluableExpression
+	hasPressure uint64 // 0=no pressure, any other value is pressure - access with atomic package
+	// configuration
+	DiscardIfBackpressure bool     `json:"discard_if_backpressure" yaml:"discard_if_backpressure"` // if true an event will always be discarded if there is some backpressure
+	Conditions            []string `yaml:"conditions" json:"conditions"`                           // our conditions
+	NegateConditions      bool     `yaml:"negate_conditions" json:"negate_conditions"`             // if true we will discard if we otherwise would not
+}
+
+// DefaultFilterConfig returns an FilterConfig struct with default values
+func DefaultFilterConfig() FilterConfig {
+	return FilterConfig{
+		FilterConfig: config.FilterConfig{
+			CommonConfig: config.CommonConfig{
+				Type: ModuleName,
+			},
+		},
+	}
+}
+
+// InitHandler initialize the filter plugin
+func InitHandler(
+	ctx context.Context,
+	raw config.ConfigRaw,
+	control config.Control,
+) (config.TypeFilterConfig, error) {
+	conf := DefaultFilterConfig()
+	conf.control = control
+	conf.ctx = ctx
+
+	if err := config.ReflectConfig(raw, &conf); err != nil {
+		return nil, err
+	}
+
+	// parse conditions
+	for _, condition := range conf.Conditions {
+		cond, err := govaluate.NewEvaluableExpressionWithFunctions(condition, filtercond.BuiltInFunctions)
+		if err == nil {
+			conf.expressions = append(conf.expressions, cond)
+		} else {
+			goglog.Logger.Errorf("%s: %s", ModuleName, err.Error())
+		}
+	}
+	if len(conf.expressions) == 0 && !conf.DiscardIfBackpressure {
+		return nil, errors.New("no conditions for discard filter")
+	}
+
+	if conf.DiscardIfBackpressure {
+		go conf.backgroundtask()
+	}
+	return &conf, nil
+}
+
+// Event the main filter event
+func (f *FilterConfig) Event(
+	ctx context.Context,
+	event logevent.LogEvent,
+) (logevent.LogEvent, bool) {
+	// check for backpressure drop
+	if f.DiscardIfBackpressure && atomic.LoadUint64(&f.hasPressure) > 0 {
+		event.FilterPos = logevent.DiscardEvent
+		return event, false
+	}
+	// handle conditions
+	var shouldDiscard bool
+	ep := filtercond.EventParameters{Event: &event}
+	for num := range f.expressions {
+		ret, err := f.expressions[num].Eval(&ep)
+		if err == nil {
+			if r, ok := ret.(bool); ok {
+				shouldDiscard = r
+			} else {
+				goglog.Logger.Warn("filter cond condition returns not a boolean, ignored")
+			}
+		} else {
+			goglog.Logger.Errorf("%s: %s", ModuleName, err.Error())
+		}
+		if shouldDiscard {
+			break
+		}
+	}
+	if f.NegateConditions {
+		shouldDiscard = !shouldDiscard
+	}
+	if shouldDiscard {
+		event.FilterPos = logevent.DiscardEvent
+		return event, false
+	}
+	return event, true
+}
+
+// backgroundtask monitors backpressure and updates the internal status. Is only started if we need to monitor backpressure.
+func (f *FilterConfig) backgroundtask() {
+	for {
+		select {
+		case <-f.control.PauseSignal():
+			atomic.AddUint64(&f.hasPressure, 1)
+		case <-f.control.ResumeSignal():
+			atomic.StoreUint64(&f.hasPressure, 0)
+		case <-f.ctx.Done():
+			return
+		}
+	}
+}

--- a/modloader/modloader.go
+++ b/modloader/modloader.go
@@ -6,6 +6,7 @@ import (
 	filteraddfield "github.com/tsaikd/gogstash/filter/addfield"
 	filtercond "github.com/tsaikd/gogstash/filter/cond"
 	filterdate "github.com/tsaikd/gogstash/filter/date"
+	filterdiscard "github.com/tsaikd/gogstash/filter/discard"
 	filtergeoip2 "github.com/tsaikd/gogstash/filter/geoip2"
 	filtergonx "github.com/tsaikd/gogstash/filter/gonx"
 	filtergrok "github.com/tsaikd/gogstash/filter/grok"
@@ -69,6 +70,7 @@ func init() {
 	config.RegistFilterHandler(filteraddfield.ModuleName, filteraddfield.InitHandler)
 	config.RegistFilterHandler(filtercond.ModuleName, filtercond.InitHandler)
 	config.RegistFilterHandler(filterdate.ModuleName, filterdate.InitHandler)
+	config.RegistFilterHandler(filterdiscard.ModuleName, filterdiscard.InitHandler)
 	config.RegistFilterHandler(filtergeoip2.ModuleName, filtergeoip2.InitHandler)
 	config.RegistFilterHandler(filtergonx.ModuleName, filtergonx.InitHandler)
 	config.RegistFilterHandler(filtergrok.ModuleName, filtergrok.InitHandler)


### PR DESCRIPTION
In this PR I have added a discard filter. This filter allows me to

1. Discard an event from further processing when I know that I will not need it. Today this has to be done by using a cond output, but you still need to send the event through all stages of processing before it is discarded.
2. Discard the event in case we have back pressure issues. This can be handy if the output supports back pressure, the input does not and discarding the event is your best option in this case.

I also rewrote the filter handling routine to allow for an event to start at a specific filter, instead of at the beginning of the list of filters. I think there are many good ways to use this. I am currently working on a filter where my goal is to identify and remove all events of a kind expect the last one. To do this I need to discard all but the last event that I need to inject for further processing from the next filter in the pipeline.

Other good examples for the discard code can be [logstash aggregate](https://www.elastic.co/guide/en/logstash/current/plugins-filters-aggregate.html) or [logstash throttling](https://www.elastic.co/guide/en/logstash/current/plugins-filters-throttle.html).