### PR TITLE
Changed geo output type

### DIFF
--- a/filter/ip2location/filterip2location.go
+++ b/filter/ip2location/filterip2location.go
@@ -20,12 +20,6 @@ const ModuleName = "ip2location"
 // ErrorTag tag added to event when process ip2location failed
 const ErrorTag = "gogstash_filter_ip2location_error"
 
-// Geo describes a geo location
-type Geo struct {
-	Lat float32 `json:"lat"`
-	Lon float32 `json:"lon"`
-}
-
 // FilterConfig holds the configuration json fields and internal objects
 type FilterConfig struct {
 	config.FilterConfig
@@ -226,7 +220,10 @@ func (f *FilterConfig) Event(ctx context.Context, event logevent.LogEvent) (loge
 		m["ISP"] = record.Isp
 	}
 	if record.Latitude != 0 || record.Longitude != 0 {
-		m["location"] = Geo{Lon: record.Longitude, Lat: record.Latitude}
+		location := make(map[string]interface{})
+		location["lon"] = record.Longitude
+		location["lat"] = record.Latitude
+		m["location"] = location
 	}
 
 	event.SetValue(f.Key, m)


### PR DESCRIPTION
The internal representation of the data is changed from a custom struct to map[string]interface{} so the data is compatible with all the other filters and helpers inside gogstash.