### PR TITLE
Fixed deadlock on codec when exiting program

### DIFF
--- a/codec/json/codecjson.go
+++ b/codec/json/codecjson.go
@@ -102,9 +102,8 @@ func (c *Codec) Encode(ctx context.Context, event logevent.LogEvent, dataChan ch
 	}
 	select {
 	case <-ctx.Done():
-		return
-	default:
-		dataChan <- output
+		return false, nil
+	case dataChan <- output:
 	}
 	return true, nil
 }

--- a/codec/json/codecjson.go
+++ b/codec/json/codecjson.go
@@ -95,12 +95,17 @@ func (c *Codec) DecodeEvent(data []byte, event *logevent.LogEvent) (err error) {
 }
 
 // Encode encodes the event to a JSON encoded message
-func (c *Codec) Encode(_ context.Context, event logevent.LogEvent, dataChan chan<- []byte) (ok bool, err error) {
+func (c *Codec) Encode(ctx context.Context, event logevent.LogEvent, dataChan chan<- []byte) (ok bool, err error) {
 	output, err := event.MarshalJSON()
 	if err != nil {
 		return false, err
 	}
-	dataChan <- output
+	select {
+	case <-ctx.Done():
+		return
+	default:
+		dataChan <- output
+	}
 	return true, nil
 }
 


### PR DESCRIPTION
I have been looking at #211 and #199, and it seems to be related to that JSON Encode() does not check the context and in some cases ends up blocking as dataChan is full. At least on my tests this seems to solve the problem.