### PR TITLE
feat(filter/mutate/replace): add variable extrapolation

### DIFF
--- a/filter/mutate/filtermutate.go
+++ b/filter/mutate/filtermutate.go
@@ -76,7 +76,7 @@ func (f *FilterConfig) Event(ctx context.Context, event logevent.LogEvent) (loge
 		event.SetValue(f.Split[0], strings.Split(event.GetString(f.Split[0]), f.Split[1]))
 	}
 	if f.Replace[0] != "" {
-		event.SetValue(f.Replace[0], strings.ReplaceAll(event.GetString(f.Replace[0]), f.Replace[1], f.Replace[2]))
+		event.SetValue(f.Replace[0], strings.ReplaceAll(event.GetString(f.Replace[0]), f.Replace[1], event.Format(f.Replace[2])))
 	}
 	if f.Merge[0] != "" {
 		event = mergeField(event, f.Merge[0], f.Merge[1])

--- a/filter/mutate/filtermutate_test.go
+++ b/filter/mutate/filtermutate_test.go
@@ -147,6 +147,40 @@ filter:
 	}
 }
 
+func Test_filter_mutate_module_replace_with_extrapolation(t *testing.T) {
+	assert := assert.New(t)
+	assert.NotNil(assert)
+	require := require.New(t)
+	require.NotNil(require)
+
+	ctx := context.Background()
+	conf, err := config.LoadFromYAML([]byte(strings.TrimSpace(`
+debugch: true
+filter:
+  - type: mutate
+    replace: ["key", ",", "%{spacer}"]
+	`)))
+	require.NoError(err)
+	require.NoError(conf.Start(ctx))
+
+	expectedEvent := logevent.LogEvent{
+		Extra: map[string]any{
+			"key":    "foo~~bar",
+			"spacer": "~~",
+		},
+	}
+
+	conf.TestInputEvent(logevent.LogEvent{
+		Extra: map[string]any{
+			"key":    "foo,bar",
+			"spacer": "~~",
+		},
+	})
+
+	if event, err := conf.TestGetOutputEvent(300 * time.Millisecond); assert.NoError(err) {
+		require.Equal(expectedEvent, event)
+	}
+}
 func Test_filter_mutate_module_merge(t *testing.T) {
 	assert := assert.New(t)
 	assert.NotNil(assert)


### PR DESCRIPTION
Add variable extrapolation to filter 'mutate/replace' to be able to replace pattern by variable content:
mutate:
  replace: ["field", "pattern", "%{another_field}"]
